### PR TITLE
[#5, #6] 공통 엔티티 및 User 엔티티 구현

### DIFF
--- a/src/main/java/com/prgrms/prolog/PrologApplication.java
+++ b/src/main/java/com/prgrms/prolog/PrologApplication.java
@@ -2,7 +2,9 @@ package com.prgrms.prolog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class PrologApplication {
 

--- a/src/main/java/com/prgrms/prolog/global/common/BaseEntity.java
+++ b/src/main/java/com/prgrms/prolog/global/common/BaseEntity.java
@@ -1,0 +1,33 @@
+package com.prgrms.prolog.global.common;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "created_by")
+	private Long createdBy;
+}

--- a/src/main/java/com/prgrms/prolog/global/config/DatabaseConfig.java
+++ b/src/main/java/com/prgrms/prolog/global/config/DatabaseConfig.java
@@ -1,4 +1,4 @@
-package com.prgrms.prolog;
+package com.prgrms.prolog.global.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;

--- a/src/main/java/com/prgrms/prolog/user/model/User.java
+++ b/src/main/java/com/prgrms/prolog/user/model/User.java
@@ -1,0 +1,100 @@
+package com.prgrms.prolog.user.model;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.springframework.util.Assert;
+
+import com.prgrms.prolog.global.common.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "users")
+public class User extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.AUTO)
+	private Long id;
+
+	@Column(nullable = false, length = 100)
+	private String email;
+
+	@Column(nullable = false, length = 100)
+	private String nickName;
+
+	@Column(nullable = true, length = 100)
+	private String introduce;
+
+	@Column(nullable = false, length = 100)
+	private String prologName;
+
+	@Column(nullable = false, length = 100)
+	private String provider;
+
+	@Column(nullable = false, length = 100)
+	private String oauthId;
+
+	@Builder
+	public User(String email, String nickName, String introduce,
+		String prologName, String provider, String oauthId) {
+
+		validateEmail(email);
+		validateNickName(nickName);
+		validateIntroduce(introduce);
+		validatePrologName(prologName);
+
+		this.email = email;
+		this.nickName = nickName;
+		this.introduce = introduce;
+		this.prologName = prologName;
+		this.provider = provider;
+		this.oauthId = oauthId;
+	}
+
+	private void validatePrologName(String prologName) {
+		Assert.hasText(prologName, "블로그 제목은 빈 값일 수 없습니다.");
+		checkOverLength(prologName, 100, "블로그 제목은 최대 100글자 이내로 작성해야 합니다.");
+	}
+
+	private void validateIntroduce(String introduce) {
+		checkOverLength(introduce, 100, "한줄 소개는 최대 100글자 이내로 작성해야 합니다.");
+	}
+
+	private void validateNickName(String nickName) {
+		Assert.hasText(nickName, "닉네임은 빈 값일 수 없습니다.");
+		checkOverLength(nickName, 100, "닉네임은 최대 100글자 이내로 작성해야 합니다.");
+	}
+
+	private void validateEmail(String email) {
+		String regex = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$";
+		Pattern pattern = Pattern.compile(regex);
+		Matcher matcher = pattern.matcher(email);
+
+		Assert.hasText(email, "이메일은 빈 값일 수 없습니다.");
+		Assert.isTrue(matcher.matches(), "이메일 형식이 올바르지 않습니다.");
+		checkOverLength(email, 100, "이메일은 최대 100글자 이내로 작성해야 합니다..");
+	}
+
+	private void checkOverLength(String text, int length, String message) {
+		if (text.length() > length) {
+			log.debug("글자 수 초과");
+			throw new IllegalArgumentException(message);
+		}
+	}
+
+}

--- a/src/main/java/com/prgrms/prolog/user/model/User.java
+++ b/src/main/java/com/prgrms/prolog/user/model/User.java
@@ -81,7 +81,7 @@ public class User extends BaseEntity {
 	}
 
 	private void validateEmail(String email) {
-		String regex = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$";
+		String regex = "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$";
 		Pattern pattern = Pattern.compile(regex);
 		Matcher matcher = pattern.matcher(email);
 

--- a/src/main/java/com/prgrms/prolog/user/model/User.java
+++ b/src/main/java/com/prgrms/prolog/user/model/User.java
@@ -97,4 +97,16 @@ public class User extends BaseEntity {
 		}
 	}
 
+	@Override
+	public String toString() {
+		return "User{" +
+			"id=" + id +
+			", email='" + email +
+			", nickName='" + nickName +
+			", introduce='" + introduce +
+			", prologName='" + prologName +
+			", provider='" + provider +
+			", oauthId='" + oauthId +
+			'}';
+	}
 }

--- a/src/main/java/com/prgrms/prolog/user/model/User.java
+++ b/src/main/java/com/prgrms/prolog/user/model/User.java
@@ -3,12 +3,12 @@ package com.prgrms.prolog.user.model;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.validation.constraints.Size;
 
 import org.springframework.util.Assert;
 
@@ -27,26 +27,29 @@ import lombok.extern.slf4j.Slf4j;
 @Table(name = "users")
 public class User extends BaseEntity {
 
+	private static final Pattern emailPattern
+		= Pattern.compile("^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$");
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
 	private Long id;
 
-	@Column(nullable = false, length = 100)
+	@Size(max = 100)
 	private String email;
 
-	@Column(nullable = false, length = 100)
+	@Size(max = 100)
 	private String nickName;
 
-	@Column(nullable = true, length = 100)
+	@Size(max = 100)
 	private String introduce;
 
-	@Column(nullable = false, length = 100)
+	@Size(max = 100)
 	private String prologName;
 
-	@Column(nullable = false, length = 100)
+	@Size(max = 100)
 	private String provider;
 
-	@Column(nullable = false, length = 100)
+	@Size(max = 100)
 	private String oauthId;
 
 	@Builder
@@ -81,10 +84,7 @@ public class User extends BaseEntity {
 	}
 
 	private void validateEmail(String email) {
-		String regex = "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$";
-		Pattern pattern = Pattern.compile(regex);
-		Matcher matcher = pattern.matcher(email);
-
+		Matcher matcher = emailPattern.matcher(email);
 		Assert.hasText(email, "이메일은 빈 값일 수 없습니다.");
 		Assert.isTrue(matcher.matches(), "이메일 형식이 올바르지 않습니다.");
 		checkOverLength(email, 100, "이메일은 최대 100글자 이내로 작성해야 합니다..");
@@ -99,14 +99,14 @@ public class User extends BaseEntity {
 
 	@Override
 	public String toString() {
-		return "User{" +
-			"id=" + id +
-			", email='" + email +
-			", nickName='" + nickName +
-			", introduce='" + introduce +
-			", prologName='" + prologName +
-			", provider='" + provider +
-			", oauthId='" + oauthId +
-			'}';
+		return "User{"
+			+ "id=" + id
+			+ ", email='" + email
+			+ ", nickName='" + nickName
+			+ ", introduce='" + introduce
+			+ ", prologName='" + prologName
+			+ ", provider='" + provider
+			+ ", oauthId='" + oauthId
+			+ '}';
 	}
 }


### PR DESCRIPTION
## 🌱 작업 사항

### BaseEntity 구현
- 작성 일자, 작성자, 수정 일자
- Auditing 기능 추가
- CreatedBy(작성자) Auditing 기능은 추후에 시큐리티 구현시 연동할 예정 

### User 구현
- 유효성 검증 로직 추가
- 시큐리티 추후에 적용 예정
- 이메일 검증시 정규식 활용
- 일단 메시지는 작성 했는데 추후에 MessageSource 추가 되면 리팩터링 하는 걸로 하겠습니다!

## 🦄 관련 이슈
close #5
close #6