### PR TITLE
[#26] Jacoco 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,11 @@ plugins {
     id 'org.springframework.boot' version '2.7.7'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
     id 'org.asciidoctor.jvm.convert' version "3.3.2"
+    id 'jacoco'
 }
 
 group = 'com.prgrms'
-version = '0.0.1-SNAPSHOT'
+version = '1.0.0'
 sourceCompatibility = '17'
 
 configurations {
@@ -60,9 +61,48 @@ dependencyManagement {
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
 
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
+}
+
+jacocoTestReport {
+    dependsOn test
+    finalizedBy 'jacocoTestCoverageVerification'
+    reports {
+        xml.required = false
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+    }
+}
+
+jacoco {
+    toolVersion = "0.8.8"
+    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir') as Directory
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'METHOD'
+                value = 'COVEREDRATIO'
+                minimum = 0.5
+            }
+
+            excludes = [
+                    '*.global*',
+                    '*.service*',
+                    '*.dto*'
+            ]
+
+        }
+
+    }
 }


### PR DESCRIPTION
## 🌱 작업 사항
- build.gradle에 플러그인 및 의존성 추가
- 최소 커버리지 50%로 설정
- 작업태스크 설정
  - 현재 커버리지 충족이 안되면 빌드 안됨
  - 빌드시 html로 report 생성
- global,service,dto 일단 예외로 두었습니다.! 추후에 복원하게습니다.  혹시 예외에 추가해야하는 클래스 있다면 이야기해주세요!!

## 🦄 관련 이슈
close #26 