### PR TITLE
[#31] JWT 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
     // Flyway dependency
     // https://mvnrepository.com/artifact/org.flywaydb/flyway-core
     implementation 'org.flywaydb:flyway-core:6.4.2'
+
+    // JWT dependency
+    // https://mvnrepository.com/artifact/com.auth0/java-jwt
+    implementation group: 'com.auth0', name: 'java-jwt', version: '4.2.1'
 }
 
 dependencyManagement {

--- a/src/main/java/com/prgrms/prolog/global/config/SecurityConfig.java
+++ b/src/main/java/com/prgrms/prolog/global/config/SecurityConfig.java
@@ -1,0 +1,55 @@
+package com.prgrms.prolog.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.prgrms.prolog.global.jwt.JwtAuthenticationEntryPoint;
+import com.prgrms.prolog.global.jwt.JwtAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+	@Override
+	public void configure(WebSecurity web) {
+		web.ignoring().antMatchers("/resources/**");
+	}
+
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+
+		http
+			.authorizeRequests()
+			.antMatchers("/docs/**").permitAll()
+			.anyRequest().authenticated()
+			.and()
+			// REST API 기반이기 때문에 사용 X
+			.httpBasic().disable()
+			.formLogin().disable()
+			.rememberMe().disable()
+			.csrf().disable()
+			.requestCache().disable()
+			.headers().disable()
+			// 세션 설정 -> 사용 X
+			.sessionManagement()
+			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.and()
+			// jwt 필터 추가
+			.exceptionHandling()
+			.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+			.and()
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+		;
+	}
+}

--- a/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthentication.java
+++ b/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthentication.java
@@ -1,0 +1,31 @@
+package com.prgrms.prolog.global.jwt;
+
+import java.util.Objects;
+
+public record JwtAuthentication(String token, String userEmail) {
+
+	public JwtAuthentication {
+		validateToken(token);
+		validateUserEmail(userEmail);
+	}
+
+	private void validateToken(String token) {
+		if (Objects.isNull(token) || token.isBlank()) {
+			throw new IllegalArgumentException("토큰이 없습니다.");
+		}
+	}
+
+	private void validateUserEmail(String userEmail) {
+		if (Objects.isNull(userEmail) || userEmail.isBlank()) {
+			throw new IllegalArgumentException("유저 이메일이 없습니다.");
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "JwtAuthentication{"
+			+ "token='" + token + '\''
+			+ ", userEmail='" + userEmail + '\''
+			+ '}';
+	}
+}

--- a/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,32 @@
+package com.prgrms.prolog.global.jwt;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint { // JWT 인증 실패시 처리할 동작
+
+	private static final String ERROR_LOG_MESSAGE = "[ERROR] {} : {}";
+
+	// private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) {
+		log.info(ERROR_LOG_MESSAGE, authException.getClass().getSimpleName(), authException.getMessage());
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+		// response.getWriter().write(objectMapper.writeValueAsString(ERROR_MESSAGE));
+	}
+}

--- a/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,67 @@
+package com.prgrms.prolog.global.jwt;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.prgrms.prolog.global.jwt.JwtTokenProvider.Claims;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private static final String headerKey = "token";
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain)
+		throws ServletException, IOException {
+
+		String token = getToken(req);
+		if (token != null) {
+			JwtAuthenticationToken authentication = createAuthentication(token);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+		filterChain.doFilter(req, res);
+	}
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return request.getRequestURI().endsWith("tokens")
+			&& request.getMethod().equalsIgnoreCase("POST");
+	}
+
+	private String getToken(HttpServletRequest request) {
+		String token = request.getHeader(headerKey);
+		if (token != null) {
+			return URLDecoder.decode(token, StandardCharsets.UTF_8);
+		}
+		return null;
+	}
+
+	private JwtAuthenticationToken createAuthentication(String token) {
+		Claims claims = jwtTokenProvider.getClaims(token);
+		return new JwtAuthenticationToken(
+			new JwtAuthentication(token, claims.getEmail()), getAuthorities(claims.getRole())
+		);
+	}
+
+	private List<GrantedAuthority> getAuthorities(String role) {
+		return List.of(new SimpleGrantedAuthority(role));
+	}
+}

--- a/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,66 @@
+package com.prgrms.prolog.global.jwt;
+
+import java.util.Collection;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+	private final Object principal;
+	private String credentials;
+
+	public JwtAuthenticationToken(Object principal, Collection<? extends GrantedAuthority> authorities) {
+		this(principal, null, authorities);
+	}
+
+	public JwtAuthenticationToken(String principal, String credentials) {
+		super(null);
+		super.setAuthenticated(false);
+
+		this.principal = principal;
+		this.credentials = credentials;
+	}
+
+	public JwtAuthenticationToken(
+		Object principal, String credentials, Collection<? extends GrantedAuthority> authorities
+	) {
+		super(authorities);
+		super.setAuthenticated(true);
+
+		this.principal = principal;
+		this.credentials = credentials;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return principal;
+	}
+
+	@Override
+	public String getCredentials() {
+		return credentials;
+	}
+
+	@Override
+	public void setAuthenticated(boolean isAuthenticated) {
+		if (isAuthenticated) {
+			throw new IllegalArgumentException("인증 정보를 확인할 수 없는 메서드 주입은 지원하지 않습니다. 생성자를 통해 생성해야 합니다.");
+		}
+		super.setAuthenticated(false);
+	}
+
+	@Override
+	public void eraseCredentials() {
+		super.eraseCredentials();
+		credentials = null;
+	}
+
+	@Override
+	public String toString() {
+		return "JwtAuthenticationToken{"
+			+ "principal=" + principal
+			+ ", credentials='" + credentials + '\''
+			+ '}';
+	}
+}

--- a/src/main/java/com/prgrms/prolog/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/prolog/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,97 @@
+package com.prgrms.prolog.global.jwt;
+
+import java.util.Base64;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Component
+public final class JwtTokenProvider {
+
+	private final String issuer; // 발행자
+	private final int expirySeconds; // 유효시간
+	private final Algorithm algorithm; // 사용할 알고리즘
+	private final JWTVerifier jwtVerifier; // jwt 변환, 검증 객체
+
+	public JwtTokenProvider(
+		@Value("${jwt.issuer}") String issuer,
+		@Value("${jwt.secret-key}") String secretKey,
+		@Value("${jwt.expiry-seconds}") int expirySeconds
+	) {
+		this.issuer = issuer;
+		this.expirySeconds = expirySeconds;
+		this.algorithm = Algorithm.HMAC512(encodeKeyToBase64(secretKey));
+		this.jwtVerifier = JWT.require(algorithm).withIssuer(issuer).build();
+	}
+
+	private static String encodeKeyToBase64(String key) {
+		return Base64.getEncoder().encodeToString(key.getBytes());
+	}
+
+	public String createAccessToken(Claims claims) {
+		Date now = new Date();
+		return JWT.create()
+			.withIssuer(issuer)
+			.withIssuedAt(now)
+			.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L))
+			.withClaim("email", claims.getEmail())
+			.withClaim("role", claims.getRole())
+			.sign(algorithm);
+	}
+
+	public Claims getClaims(String token) throws JWTVerificationException { // 기간 만료 이거나 올바르지 않은 토큰인 경우 예외 발생
+		return new Claims(jwtVerifier.verify(token));
+	}
+
+	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class Claims {
+
+		private String email;
+		private String role;
+		private Date iat;
+		private Date exp;
+
+		protected Claims(DecodedJWT decodedJwt) {
+			Claim email = decodedJwt.getClaim("email");
+			if (!email.isNull()) {
+				this.email = email.asString();
+			}
+			Claim role = decodedJwt.getClaim("role");
+			if (!role.isNull()) {
+				this.role = role.asString();
+			}
+			this.iat = decodedJwt.getIssuedAt();
+			this.exp = decodedJwt.getExpiresAt();
+		}
+
+		public static Claims from(String email, String role) {
+			Claims claims = new Claims();
+			claims.email = email;
+			claims.role = role;
+			return claims;
+		}
+
+		@Override
+		public String toString() {
+			return "Claims{"
+				+ "email='" + email + '\''
+				+ ", role='" + role + '\''
+				+ ", iat=" + iat
+				+ ", exp=" + exp
+				+ '}';
+		}
+	}
+}

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,0 +1,5 @@
+# jwt 설정
+jwt:
+  issuer: prgrms
+  secret-key: ProgrammersDevCourseBackEndRTeamProlog
+  expiry-seconds: 60

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,10 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
 
+  # security 설정
+  profiles:
+    include: security
+
   # Flyway 설정
   flyway:
     enabled: true


### PR DESCRIPTION
## 🌱 작업 사항
 - java-jwt 라이브러리 의존성 추가 (jjwt와 비교했을때 배운것이 해당 라이브러리였기 때문에 그대로 사용)
 - spring-security.yml 파일에 jwt 발행자, 비밀키, 만료시간 설정(추후에 깃허브 시크릿으로 올릴 수 있게 함. 현재는 제외)
 - JWT 기능 구현 
   - 토큰 생성 및 검증 객체 (JwtTokenProvider)
     - email을 제공할 정보로 사용함. (사용자 식별정보)
   - 토큰을 이용한 로그인 요청 담을 객체 (JwtAuthenticationToken)
   - 인증된 사용자를 표현하는 객체 (JwtAuthentication)
   - jwt 인증을 진행할 필터 (JwtAuthenticationFilter)
   - jwt 인증 실패시 처리를 위한 객체 (JwtAuthenticationEntryPoint)
- Security 설정 

아직 OAuth도 없기 때문에 추후에 기능 구현하면서 연결하겠습니다. 다만, 기본 기능이 많이 변경되지는 않을 것 같습니다.
에러 메시지나 로그도 추가해서 추후에 리팩터링 하겠습니다!
## 🦄 관련 이슈
close #31 