### PR TITLE
[#16] 디폴트 회원 가입 및 로그인 기능 구현 

### DIFF
--- a/src/main/java/com/prgrms/prolog/domain/user/api/UserController.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/api/UserController.java
@@ -1,0 +1,28 @@
+package com.prgrms.prolog.domain.user.api;
+
+import static com.prgrms.prolog.domain.user.dto.UserDto.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prgrms.prolog.domain.user.service.UserService;
+import com.prgrms.prolog.global.jwt.JwtAuthentication;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping(name = "/api/v1/users")
+@RestController
+public class UserController {
+
+	private final UserService userService;
+
+	@GetMapping("/me")
+	ResponseEntity<UserInfo> myPage(@AuthenticationPrincipal JwtAuthentication user) {
+		return ResponseEntity.ok(userService.findByEmail(user.userEmail()));
+	}
+
+}

--- a/src/main/java/com/prgrms/prolog/domain/user/dto/UserDto.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/dto/UserDto.java
@@ -1,0 +1,39 @@
+package com.prgrms.prolog.domain.user.dto;
+
+import com.prgrms.prolog.domain.user.model.User;
+
+public class UserDto {
+
+	public record UserInfo(
+		String email,
+		String nickName,
+		String introduce,
+		String prologName
+	) {
+		public UserInfo(User user) {
+			this(
+				user.getEmail(),
+				user.getNickName(),
+				user.getIntroduce(),
+				user.getPrologName()
+			);
+		}
+	}
+
+	public record UserProfile(
+		String email,
+		String nickName,
+		String provider,
+		String oauthId
+	) {
+		UserProfile(User user) {
+			this(
+				user.getEmail(),
+				user.getNickName(),
+				user.getProvider(),
+				user.getOauthId()
+			);
+		}
+	}
+
+}

--- a/src/main/java/com/prgrms/prolog/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.prgrms.prolog.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.prgrms.prolog.domain.user.model.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/prgrms/prolog/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/service/UserService.java
@@ -1,0 +1,14 @@
+package com.prgrms.prolog.domain.user.service;
+
+import static com.prgrms.prolog.domain.user.dto.UserDto.*;
+
+public interface UserService {
+
+	/* 사용자 로그인 */
+	UserInfo login(UserProfile userProfile);
+
+	/* 이메일로 사용자 조회 */
+	UserInfo findByEmail(String email);
+
+}
+

--- a/src/main/java/com/prgrms/prolog/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,53 @@
+package com.prgrms.prolog.domain.user.service;
+
+import static com.prgrms.prolog.domain.user.dto.UserDto.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.prolog.domain.user.model.User;
+import com.prgrms.prolog.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class UserServiceImpl implements UserService {
+
+	private static final String DEFAULT_INTRODUCE = "한줄 소개를 입력해주세요.";
+
+	private final UserRepository userRepository;
+
+	/* [사용자 조회] 이메일 값으로 등록된 유저 정보 찾아서 제공 */
+	@Override
+	public UserInfo findByEmail(String email) {
+		return userRepository.findByEmail(email)
+			.map(UserInfo::new)
+			.orElseThrow(IllegalArgumentException::new);
+	}
+
+	/* [로그인] 등록된 사용자인지 확인해서 맞는 경우 정보 제공, 아닌 경우 등록 진행 */
+	@Transactional
+	public UserInfo login(UserProfile userProfile) {
+		return userRepository.findByEmail(userProfile.email())
+			.map(UserInfo::new)
+			.orElseGet(() -> register(userProfile));
+	}
+
+	/* [사용자 등록] 디폴트 설정 값으로 회원가입 진행 */
+	private UserInfo register(UserProfile userProfile) {
+		return new UserInfo(
+			userRepository.save(
+				User.builder()
+					.email(userProfile.email())
+					.nickName(userProfile.nickName())
+					.introduce(DEFAULT_INTRODUCE)
+					.prologName(userProfile.nickName() + "의 prolog")
+					.provider(userProfile.provider())
+					.oauthId(userProfile.oauthId())
+					.build()
+			)
+		);
+	}
+}


### PR DESCRIPTION
## 🌱 작업 사항
### USER
- Controller, Service, Repository, DTO 구현
- Default URI Path: `/api/v1/users`
  - API 버전닝 사용
- API
  - `/me`: 사용자 정보 제공 API
- Method
  - findByEmail: 이메일로 사용자 조회
  - login: 사용자 로그인
  - register: 디폴트 값으로 회원가입 
- DTO
  - 생성자로 Convert
  - UserInfo: 이메일, 닉네임, 한줄 소개, 블로그 제목 (사용자 정보 제공 DTO)
  - UserProfile: 이메일, 닉네임, provider, oauthId (리소스 서버로 부터 받아올 정보 DTO)  
## 🦄 관련 이슈
close #16