### PR TITLE
[#12] restdocs-swagger 변환 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,12 @@
+import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '2.7.7'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
-    id 'org.asciidoctor.jvm.convert' version "3.3.2"
+    id 'org.hidetake.swagger.generator' version '2.18.2'
+    id 'com.epages.restdocs-api-spec' version '0.16.2'
     id 'jacoco'
 }
 
@@ -20,8 +24,13 @@ repositories {
     mavenCentral()
 }
 
+swaggerSources {
+    sample {
+        setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
+    }
+}
+
 ext {
-    set('snippetsDir', file("build/generated-snippets"))
     set('testcontainersVersion', "1.17.6")
 }
 
@@ -32,7 +41,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // RestDocs API SPEC
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.2'
+
+    // Swagger UI
+    swaggerUI 'org.webjars:swagger-ui:4.11.1'
+
     testImplementation 'org.springframework.security:spring-security-test'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
@@ -62,15 +77,34 @@ dependencyManagement {
     }
 }
 
+openapi3 {
+    setServer("http://localhost:8080")
+    title = "restdocs-swagger API Documentation"
+    description = "Spring REST Docs with SwaggerUI."
+    version = "0.0.1"
+    format = "yaml"
+}
+
 tasks.named('test') {
-    outputs.dir snippetsDir
     useJUnitPlatform()
     finalizedBy jacocoTestReport
 }
 
-tasks.named('asciidoctor') {
-    inputs.dir snippetsDir
-    dependsOn test
+tasks.withType(GenerateSwaggerUI).configureEach {
+    dependsOn 'openapi3'
+}
+
+tasks.register('copySwaggerUI', Copy) {
+    dependsOn 'generateSwaggerUISample'
+
+    def generateSwaggerUISampleTask = tasks.named('generateSwaggerUISample', GenerateSwaggerUI).get()
+
+    from("${generateSwaggerUISampleTask.outputDir}")
+    into("${project.buildDir}/resources/main/static/docs")
+}
+
+tasks.withType(BootJar).configureEach {
+    dependsOn 'copySwaggerUI'
 }
 
 jacocoTestReport {

--- a/src/test/java/com/prgrms/prolog/config/RestDocsConfig.java
+++ b/src/test/java/com/prgrms/prolog/config/RestDocsConfig.java
@@ -1,0 +1,20 @@
+package com.prgrms.prolog.config;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+	@Bean
+	public RestDocumentationResultHandler write() {
+		return MockMvcRestDocumentationWrapper.document("{class-name}/{method-name}",
+			preprocessRequest(prettyPrint()),
+			preprocessResponse(prettyPrint()));
+	}
+}


### PR DESCRIPTION
## 🌱 작업 사항
- build 설정 변경
  - asciidoctor 설정 삭제
  - swaggerUI 설정 추가
  - restdocs-api-spec 설정 추가
  - openapi3 설정 추가
- restdocs 자바 설정 파일 추가

### 실행 과정 

- Controller 샘플 테스트 코드
```java
@SpringBootTest
@Import(RestDocsConfig.class)
@ExtendWith(RestDocumentationExtension.class)
class TestControllerTest {

	@Autowired
	RestDocumentationResultHandler restDocs;

	MockMvc mockMvc;

	@BeforeEach
	void setUpRestDocs(WebApplicationContext webApplicationContext,
		RestDocumentationContextProvider restDocumentation) {
		this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
			.apply(documentationConfiguration(restDocumentation))
			.alwaysDo(restDocs)
			.build();
	}

	@Test
	void v1Test() throws Exception {

		JSONObject jsonObject = new JSONObject();
		jsonObject.accumulate("title", "v1 테스트 제목");
		jsonObject.accumulate("content", "v1 테스트 내용");
		String request = jsonObject.toString();

		mockMvc.perform(RestDocumentationRequestBuilders.post("/v1")
				.contentType(MediaType.APPLICATION_JSON)
				.content(request))
			.andExpect(status().isOk())
			.andDo(restDocs.document(
				requestFields(
					fieldWithPath("title").description("제목"),
					fieldWithPath("content").description("내용")
				),
				responseFields(
					fieldWithPath("title").description("응답 제목"),
					fieldWithPath("content").description("응답 내용")
				)
			));

	}
}
```

- build -> bootRun
- [localhost:8080/docs/index.html](localhost:8080/docs/index.html) 접속
<img width="1072" alt="Restdocs-SwaggerUI API Document Sample" src="https://user-images.githubusercontent.com/82203978/213099961-b6868024-4cd7-4ad0-a79f-50778c3ac0c7.png">



## 🦄 관련 이슈
close #12