### PR TITLE
[#32] OAuth 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ jacocoTestCoverageVerification {
 
             excludes = [
                     '*.global*',
+                    '*.service*',
                     '*.dto*'
             ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' // OAuth2-Client dependency
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
@@ -54,6 +55,7 @@ dependencies {
     // JWT dependency
     // https://mvnrepository.com/artifact/com.auth0/java-jwt
     implementation group: 'com.auth0', name: 'java-jwt', version: '4.2.1'
+
 }
 
 dependencyManagement {
@@ -102,7 +104,6 @@ jacocoTestCoverageVerification {
 
             excludes = [
                     '*.global*',
-                    '*.service*',
                     '*.dto*'
             ]
 

--- a/src/main/java/com/prgrms/prolog/PrologApplication.java
+++ b/src/main/java/com/prgrms/prolog/PrologApplication.java
@@ -2,9 +2,7 @@ package com.prgrms.prolog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class PrologApplication {
 

--- a/src/main/java/com/prgrms/prolog/domain/user/dto/UserDto.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/dto/UserDto.java
@@ -2,8 +2,11 @@ package com.prgrms.prolog.domain.user.dto;
 
 import com.prgrms.prolog.domain.user.model.User;
 
+import lombok.Builder;
+
 public class UserDto {
 
+	@Builder
 	public record UserInfo(
 		String email,
 		String nickName,
@@ -20,20 +23,14 @@ public class UserDto {
 		}
 	}
 
+	@Builder
 	public record UserProfile(
 		String email,
 		String nickName,
 		String provider,
 		String oauthId
 	) {
-		UserProfile(User user) {
-			this(
-				user.getEmail(),
-				user.getNickName(),
-				user.getProvider(),
-				user.getOauthId()
-			);
-		}
+
 	}
 
 }

--- a/src/main/java/com/prgrms/prolog/global/common/BaseEntity.java
+++ b/src/main/java/com/prgrms/prolog/global/common/BaseEntity.java
@@ -29,5 +29,5 @@ public abstract class BaseEntity {
 	private LocalDateTime updatedAt;
 
 	@Column(name = "created_by")
-	private Long createdBy;
+	private String createdBy;
 }

--- a/src/main/java/com/prgrms/prolog/global/config/JpaConfig.java
+++ b/src/main/java/com/prgrms/prolog/global/config/JpaConfig.java
@@ -1,0 +1,43 @@
+package com.prgrms.prolog.global.config;
+
+import java.util.Optional;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.prgrms.prolog.global.jwt.JwtAuthentication;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+	private static final GrantedAuthority PERMISSION_ROLE
+		= new SimpleGrantedAuthority("USER");
+
+	@Bean
+	public AuditorAware<String> auditorAwareProvider() {
+		return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+			.map(SecurityContext::getAuthentication)
+			.map(this::getUser);
+	}
+
+	private String getUser(Authentication authentication) { //TODO: 메소드명 바꾸기
+		if (isValidAuthentication(authentication)) {
+			JwtAuthentication user = (JwtAuthentication)authentication.getPrincipal();
+			return user.userEmail();
+		}
+		return null;
+	}
+
+	private boolean isValidAuthentication(Authentication authentication) {
+		return authentication != null && authentication.isAuthenticated()
+			&& authentication.getAuthorities().contains(PERMISSION_ROLE);
+	}
+}

--- a/src/main/java/com/prgrms/prolog/global/config/SecurityConfig.java
+++ b/src/main/java/com/prgrms/prolog/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.prgrms.prolog.global.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -10,6 +11,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 import com.prgrms.prolog.global.jwt.JwtAuthenticationEntryPoint;
 import com.prgrms.prolog.global.jwt.JwtAuthenticationFilter;
+import com.prgrms.prolog.global.oauth.OAuthAuthenticationSuccessHandler;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +22,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final OAuthAuthenticationSuccessHandler oauthAuthenticationSuccessHandler;
 
 	@Override
 	public void configure(WebSecurity web) {
@@ -41,9 +44,15 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			.csrf().disable()
 			.requestCache().disable()
 			.headers().disable()
+			.logout()
+			.and()
 			// 세션 설정 -> 사용 X
 			.sessionManagement()
 			.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.and()
+			//OAuth 로그인
+			.oauth2Login()
+			.successHandler(oauthAuthenticationSuccessHandler)
 			.and()
 			// jwt 필터 추가
 			.exceptionHandling()

--- a/src/main/java/com/prgrms/prolog/global/oauth/OAuthAuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/prolog/global/oauth/OAuthAuthenticationSuccessHandler.java
@@ -1,0 +1,51 @@
+package com.prgrms.prolog.global.oauth;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.prgrms.prolog.domain.user.dto.UserDto.UserProfile;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class OAuthAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+	private static final String CHARACTER_ENCODING = "UTF-8";
+	private static final String CONTENT_TYPE = "application/json";
+	private static final String SLASH = "/";
+
+	private final OAuthService oauthService;
+
+	@Override
+	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+		Authentication authentication) {
+		String providerName = extractProviderName(request);
+		Object principal = authentication.getPrincipal();
+
+		if (principal instanceof OAuth2User oauth2User) {
+			UserProfile userProfile = OAuthProvider.toUserProfile(oauth2User, providerName);
+			String accessToken = oauthService.login(userProfile);
+			setResponse(response, accessToken);
+		}
+	}
+
+	private void setResponse(HttpServletResponse response, String accessToken) {
+		response.setStatus(HttpStatus.OK.value());
+		response.setContentType(CONTENT_TYPE);
+		response.setCharacterEncoding(CHARACTER_ENCODING);
+		response.setHeader("token", accessToken);
+	}
+
+	private String extractProviderName(HttpServletRequest request) {
+		String[] splitURI = request.getRequestURI().split(SLASH);
+		return splitURI[splitURI.length - 1];
+	}
+
+}

--- a/src/main/java/com/prgrms/prolog/global/oauth/OAuthProvider.java
+++ b/src/main/java/com/prgrms/prolog/global/oauth/OAuthProvider.java
@@ -1,0 +1,27 @@
+package com.prgrms.prolog.global.oauth;
+
+import static com.prgrms.prolog.domain.user.dto.UserDto.*;
+
+import java.util.Map;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OAuthProvider {
+
+	public static UserProfile toUserProfile(OAuth2User oauth, String providerName) {
+		Map<String, Object> response = oauth.getAttributes();
+		Map<String, Object> properties = oauth.getAttribute("properties");
+		Map<String, Object> account = oauth.getAttribute("kakao_account");
+
+		return UserProfile.builder()
+			.email(String.valueOf(account.get("email")))
+			.nickName(String.valueOf(properties.get("nickname")))
+			.oauthId(String.valueOf(response.get("id")))
+			.provider(providerName)
+			.build();
+	}
+}

--- a/src/main/java/com/prgrms/prolog/global/oauth/OAuthService.java
+++ b/src/main/java/com/prgrms/prolog/global/oauth/OAuthService.java
@@ -1,0 +1,27 @@
+package com.prgrms.prolog.global.oauth;
+
+import static com.prgrms.prolog.domain.user.dto.UserDto.*;
+import static com.prgrms.prolog.global.jwt.JwtTokenProvider.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.prolog.domain.user.service.UserService;
+import com.prgrms.prolog.global.jwt.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class OAuthService {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final UserService userService;
+
+	@Transactional
+	public String login(UserProfile userProfile) {
+		UserInfo user = userService.login(userProfile);
+		return jwtTokenProvider.createAccessToken(Claims.from(user.email(), "ROLE_USER"));
+	}
+}

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -11,8 +11,8 @@ spring:
         registration:
           kakao:
             client-name: kakao
-            client-id: { CLIENT_ID }
-            client-secret: { CLIENT_SECRET }
+            client-id: ${CLIENT_ID}
+            client-secret: ${CLIENT_SECRET}
             scope: profile_nickname, account_email
             redirect-uri: "http://localhost:8080/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -3,3 +3,23 @@ jwt:
   issuer: prgrms
   secret-key: ProgrammersDevCourseBackEndRTeamProlog
   expiry-seconds: 60
+
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-name: kakao
+            client-id:
+            client-secret:
+            scope: profile_nickname, profile_image
+            redirect-uri: "http://localhost:8080/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: POST
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -11,8 +11,8 @@ spring:
         registration:
           kakao:
             client-name: kakao
-            client-id:
-            client-secret:
+            client-id: { CLIENT_ID }
+            client-secret: { CLIENT_SECRET }
             scope: profile_nickname, account_email
             redirect-uri: "http://localhost:8080/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -13,7 +13,7 @@ spring:
             client-name: kakao
             client-id:
             client-secret:
-            scope: profile_nickname, profile_image
+            scope: profile_nickname, account_email
             redirect-uri: "http://localhost:8080/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
             client-authentication-method: POST


### PR DESCRIPTION
## 🌱 작업 사항
### KAKAO OAuth
- spring-boot-starter-oauth2-client 의존성 추가
- OAuthProvider : 리소스 서버로 부터 받아온 정보 추출후 바인딩
- OAuthService : 사용자 정보를 바탕으로 회원가입 여부 확인 후 토큰 발급
- OAuthAuthenticationSuccessHandler :  OAuth 로그인 성공시 진행할 로직을 수행 
(OAuth2User를 OAuthProvider 넘기고 정보를 받아서 OAuthService로 전달 후 토큰을 받아와서 응답에 추가)
-  application-security에 OAuth 설정 추가 (깃허브 시크릿 키 사용해서 중요 정보 보호)
- JPA Auditing createBy 자동 주입 기능 구현 (security를 통해 Authentication의 이메일 추출 후 바인딩) 
## 🦄 관련 이슈
close #32 