### PR TITLE
[#66] Jwt & OAuth 리팩터링 및 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,7 +152,8 @@ jacocoTestCoverageVerification {
 
             excludes = [
                     '*.global*',
-                    '*.service*',
+                    '*.series*',
+                    '*.comment*',
                     '*.dto*'
             ]
 

--- a/src/main/java/com/prgrms/prolog/domain/comment/api/CommentController.java
+++ b/src/main/java/com/prgrms/prolog/domain/comment/api/CommentController.java
@@ -32,8 +32,7 @@ public class CommentController {
 		@Valid @RequestBody CreateCommentRequest request,
 		@AuthenticationPrincipal JwtAuthentication user
 	) {
-		String userEmail = user.userEmail();
-		commentService.save(request, userEmail, postId);
+		commentService.save(request, user.id(), postId);
 		return ResponseEntity.status(CREATED).build();
 	}
 
@@ -44,8 +43,7 @@ public class CommentController {
 		@Valid @RequestBody UpdateCommentRequest request,
 		@AuthenticationPrincipal JwtAuthentication user
 	) {
-		String userEmail = user.userEmail();
-		commentService.update(request, userEmail, commentId);
+		commentService.update(request, user.id(), commentId);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/prgrms/prolog/domain/comment/service/CommentService.java
+++ b/src/main/java/com/prgrms/prolog/domain/comment/service/CommentService.java
@@ -3,6 +3,6 @@ package com.prgrms.prolog.domain.comment.service;
 import static com.prgrms.prolog.domain.comment.dto.CommentDto.*;
 
 public interface CommentService {
-	Long save(CreateCommentRequest request, String email, Long postId);
-	Long update(UpdateCommentRequest request, String email, Long commentId);
+	Long save(CreateCommentRequest request, Long userId, Long postId);
+	Long update(UpdateCommentRequest request, Long userId, Long commentId);
 }

--- a/src/main/java/com/prgrms/prolog/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/prgrms/prolog/domain/comment/service/CommentServiceImpl.java
@@ -26,19 +26,18 @@ public class CommentServiceImpl implements CommentService {
 
 	@Override
 	@Transactional
-	public Long save(CreateCommentRequest request, String email, Long postId) {
+	public Long save(CreateCommentRequest request, Long userId, Long postId) {
 		Post findPost = getFindPostBy(postId);
-		User findUser = getFindUserBy(email);
+		User findUser = getFindUserBy(userId);
 		Comment comment = buildComment(request, findPost, findUser);
 		return commentRepository.save(comment).getId();
 	}
 
 	@Override
 	@Transactional
-	public Long update(UpdateCommentRequest request, String email, Long commentId) {
+	public Long update(UpdateCommentRequest request, Long userId, Long commentId) {
 		Comment findComment = commentRepository.joinUserByCommentId(commentId);
 		validateCommentNotNull(findComment);
-		validateCommentOwnerNotSameEmail(email, findComment);
 		findComment.changeContent(request.content());
 		return findComment.getId();
 	}
@@ -51,20 +50,14 @@ public class CommentServiceImpl implements CommentService {
 			.build();
 	}
 
-	private User getFindUserBy(String email) {
-		return userRepository.findByEmail(email)
+	private User getFindUserBy(Long userId) {
+		return userRepository.findById(userId)
 			.orElseThrow(() -> new IllegalArgumentException("exception.user.notExists"));
 	}
 
 	private Post getFindPostBy(Long postId) {
 		return postRepository.findById(postId)
 			.orElseThrow(() -> new IllegalArgumentException("exception.post.notExists"));
-	}
-
-	private void validateCommentOwnerNotSameEmail(String email, Comment  comment) {
-		if (! comment.checkUserEmail(email)) {
-			throw new IllegalArgumentException("exception.user.email.notSame");
-		}
 	}
 
 	private void validateCommentNotNull(Comment comment) {

--- a/src/main/java/com/prgrms/prolog/domain/post/api/PostController.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/api/PostController.java
@@ -38,16 +38,15 @@ public class PostController {
 	@PostMapping()
 	public ResponseEntity<Void> save(
 		@Valid @RequestBody CreateRequest create,
-		@AuthenticationPrincipal JwtAuthentication jwt
+		@AuthenticationPrincipal JwtAuthentication user
 	) {
-		String userEmail = jwt.userEmail();
-		Long savePostId = postService.save(create, userEmail);
+		Long savePostId = postService.save(create, user.id());
 		URI location = UriComponentsBuilder.fromUriString("/api/v1/posts/" + savePostId).build().toUri();
 		return ResponseEntity.created(location).build();
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<PostResponse> findById(@PathVariable Long id) {
+	public ResponseEntity<PostResponse> findById(@PathVariable Long id) { // 비공개 처리는?
 		PostResponse findPost = postService.findById(id);
 		return ResponseEntity.ok(findPost);
 	}

--- a/src/main/java/com/prgrms/prolog/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/dto/PostResponse.java
@@ -1,20 +1,22 @@
 package com.prgrms.prolog.domain.post.dto;
 
+import static com.prgrms.prolog.domain.user.dto.UserDto.UserProfile.*;
+
 import java.util.List;
 
 import com.prgrms.prolog.domain.comment.model.Comment;
 import com.prgrms.prolog.domain.post.model.Post;
-import com.prgrms.prolog.domain.user.dto.UserResponse;
+import com.prgrms.prolog.domain.user.dto.UserDto.UserProfile;
 
 public record PostResponse(String title,
 						   String content,
 						   boolean openStatus,
-						   UserResponse.findResponse user,
+						   UserProfile user,
 						   List<Comment> comment,
 						   int commentCount) {
 
 	public static PostResponse toPostResponse(Post post) {
 		return new PostResponse(post.getTitle(), post.getContent(), post.isOpenStatus(),
-			UserResponse.findResponse.toUserResponse(post.getUser()), post.getComments(), post.getComments().size());
+			toUserProfile(post.getUser()), post.getComments(), post.getComments().size());
 	}
 }

--- a/src/main/java/com/prgrms/prolog/domain/post/service/PostService.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/service/PostService.java
@@ -28,8 +28,8 @@ public class PostService {
 		this.userRepository = userRepository;
 	}
 
-	public Long save(CreateRequest create, String userEmail) {
-		User user = userRepository.findByEmail(userEmail)
+	public Long save(CreateRequest create, Long userId) {
+		User user = userRepository.findById(userId)
 			.orElseThrow(() -> new IllegalArgumentException(USER_NOT_EXIST_MESSAGE));
 		Post post = postRepository.save(CreateRequest.toEntity(create, user));
 		return post.getId();

--- a/src/main/java/com/prgrms/prolog/domain/user/api/UserController.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/api/UserController.java
@@ -21,10 +21,12 @@ public class UserController {
 	private final UserService userService;
 
 	@GetMapping("/me")
-	ResponseEntity<UserInfo> myPage(
+	ResponseEntity<UserProfile> getMyProfile(
 		@AuthenticationPrincipal JwtAuthentication user
 	) {
-		return ResponseEntity.ok(userService.findByEmail(user.userEmail()));
+		return ResponseEntity.ok(
+			userService.findUserProfileByUserId(user.id())
+		);
 	}
 
 }

--- a/src/main/java/com/prgrms/prolog/domain/user/dto/UserDto.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/dto/UserDto.java
@@ -7,30 +7,37 @@ import lombok.Builder;
 public class UserDto {
 
 	@Builder
-	public record UserInfo(
+	public record UserProfile(
+		Long id,
 		String email,
 		String nickName,
 		String introduce,
-		String prologName
+		String prologName,
+		String profileImgUrl
 	) {
-		public UserInfo(User user) {
-			this(
+		public static UserProfile toUserProfile(User user) {
+			return new UserProfile(
+				user.getId(),
 				user.getEmail(),
 				user.getNickName(),
 				user.getIntroduce(),
-				user.getPrologName()
+				user.getPrologName(),
+				user.getProfileImgUrl()
 			);
 		}
 	}
 
 	@Builder
-	public record UserProfile(
+	public record UserInfo(
 		String email,
 		String nickName,
 		String provider,
-		String oauthId
+		String oauthId,
+		String profileImgUrl
 	) {
 
 	}
 
+	public record IdResponse(Long id) {
+	}
 }

--- a/src/main/java/com/prgrms/prolog/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/model/User.java
@@ -69,13 +69,14 @@ public class User extends BaseEntity {
 
 	@Builder
 	public User(String email, String nickName, String introduce,
-		String prologName, String provider, String oauthId) {
+		String prologName, String provider, String oauthId, String profileImgUrl) {
 		this.email = validateEmail(email);
 		this.nickName = validateNickName(nickName);
 		this.introduce = validateIntroduce(introduce);
 		this.prologName = validatePrologName(prologName);
 		this.provider = Objects.requireNonNull(provider, "provider" + NULL_VALUE_MESSAGE);
 		this.oauthId = Objects.requireNonNull(oauthId, "oauthId" + NULL_VALUE_MESSAGE);
+		this.profileImgUrl = profileImgUrl;
 	}
 
 	private String validatePrologName(String prologName) {

--- a/src/main/java/com/prgrms/prolog/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/model/User.java
@@ -54,6 +54,8 @@ public class User extends BaseEntity {
 	private Long id;
 	@Size(max = 100)
 	private String email;
+	@Size(max = 255)
+	private String profileImgUrl;
 	@Size(max = 100)
 	private String nickName;
 	@Size(max = 100)

--- a/src/main/java/com/prgrms/prolog/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package com.prgrms.prolog.domain.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.prgrms.prolog.domain.user.model.User;
@@ -10,5 +11,11 @@ import com.prgrms.prolog.domain.user.model.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-	Optional<User> findByEmail(String email);
+	@Query("""
+		SELECT u
+		FROM User u
+		WHERE u.provider = :provider
+		and u.oauthId = :oauthId
+		""")
+	Optional<User> findByProviderAndOauthId(String provider, String oauthId);
 }

--- a/src/main/java/com/prgrms/prolog/domain/user/service/UserService.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/service/UserService.java
@@ -4,11 +4,11 @@ import static com.prgrms.prolog.domain.user.dto.UserDto.*;
 
 public interface UserService {
 
-	/* 사용자 로그인 */
-	UserInfo login(UserProfile userProfile);
+	/* 사용자 회원 가입 */
+	IdResponse signUp(UserInfo userInfo);
 
-	/* 이메일로 사용자 조회 */
-	UserInfo findByEmail(String email);
+	/* 사용자 조회 */
+	UserProfile findUserProfileByUserId(Long userId);
 
 }
 

--- a/src/main/java/com/prgrms/prolog/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/service/UserServiceImpl.java
@@ -19,35 +19,37 @@ public class UserServiceImpl implements UserService {
 
 	private final UserRepository userRepository;
 
-	/* [사용자 조회] 이메일 값으로 등록된 유저 정보 찾아서 제공 */
+	/* [사용자 조회] 사용자 ID를 통해 등록된 유저 정보 찾아서 제공 */
 	@Override
-	public UserInfo findByEmail(String email) {
-		return userRepository.findByEmail(email)
-			.map(UserInfo::new)
-			.orElseThrow(IllegalArgumentException::new);
+	public UserProfile findUserProfileByUserId(Long userId) {
+		return userRepository.findById(userId)
+			.map(UserProfile::toUserProfile)
+			.orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 	}
 
-	/* [로그인] 등록된 사용자인지 확인해서 맞는 경우 정보 제공, 아닌 경우 등록 진행 */
+	/* [회원 가입] 등록된 사용자 인지 확인해서 맞는 경우 유저ID 제공, 아닌 경우 사용자 등록 */
 	@Transactional
-	public UserInfo login(UserProfile userProfile) {
-		return userRepository.findByEmail(userProfile.email())
-			.map(UserInfo::new)
-			.orElseGet(() -> register(userProfile));
+	public IdResponse signUp(UserInfo userInfo) {
+		return new IdResponse(
+			userRepository
+				.findByProviderAndOauthId(userInfo.provider(), userInfo.oauthId())
+				.map(User::getId)
+				.orElseGet(() -> register(userInfo).getId())
+		);
 	}
 
 	/* [사용자 등록] 디폴트 설정 값으로 회원가입 진행 */
-	private UserInfo register(UserProfile userProfile) {
-		return new UserInfo(
-			userRepository.save(
+	private User register(UserInfo userInfo) {
+		return userRepository.save(
 				User.builder()
-					.email(userProfile.email())
-					.nickName(userProfile.nickName())
+					.email(userInfo.email())
+					.nickName(userInfo.nickName())
 					.introduce(DEFAULT_INTRODUCE)
-					.prologName(userProfile.nickName() + "의 prolog")
-					.provider(userProfile.provider())
-					.oauthId(userProfile.oauthId())
+					.prologName(userInfo.nickName() + "의 prolog")
+					.provider(userInfo.provider())
+					.oauthId(userInfo.oauthId())
+					.profileImgUrl(userInfo.profileImgUrl())
 					.build()
-			)
-		);
+			);
 	}
 }

--- a/src/main/java/com/prgrms/prolog/global/config/JpaConfig.java
+++ b/src/main/java/com/prgrms/prolog/global/config/JpaConfig.java
@@ -25,13 +25,13 @@ public class JpaConfig {
 	public AuditorAware<String> auditorAwareProvider() {
 		return () -> Optional.ofNullable(SecurityContextHolder.getContext())
 			.map(SecurityContext::getAuthentication)
-			.map(this::getUser);
+			.map(this::getCreatorInfo);
 	}
 
-	private String getUser(Authentication authentication) { //TODO: 메소드명 바꾸기
+	private String getCreatorInfo(Authentication authentication) {
 		if (isValidAuthentication(authentication)) {
 			JwtAuthentication user = (JwtAuthentication)authentication.getPrincipal();
-			return user.userEmail();
+			return user.id().toString();
 		}
 		return null;
 	}

--- a/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthentication.java
+++ b/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthentication.java
@@ -2,13 +2,13 @@ package com.prgrms.prolog.global.jwt;
 
 import java.util.Objects;
 
-public record JwtAuthentication(String token, String userEmail) {
+public record JwtAuthentication(String token, Long id) {
 
 	public JwtAuthentication {
 		validateToken(token);
-		validateUserEmail(userEmail);
-
+		validateId(id);
 	}
+
 
 	private void validateToken(String token) {
 		if (Objects.isNull(token) || token.isBlank()) {
@@ -16,17 +16,17 @@ public record JwtAuthentication(String token, String userEmail) {
 		}
 	}
 
-	private void validateUserEmail(String userEmail) {
-		if (Objects.isNull(userEmail) || userEmail.isBlank()) {
-			throw new IllegalArgumentException("유저 이메일이 없습니다.");
+	private void validateId(Long userId) {
+		if (Objects.isNull(userId) || userId <= 0L) {
+			throw new IllegalArgumentException("유저의 ID가 없습니다.");
 		}
 	}
 
 	@Override
 	public String toString() {
-		return "JwtAuthentication{"
-			+ "token='" + token + '\''
-			+ ", userEmail='" + userEmail + '\''
-			+ '}';
+		return "JwtAuthentication{" +
+			"token='" + token + '\'' +
+			", id='" + id + '\'' +
+			'}';
 	}
 }

--- a/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/prgrms/prolog/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,12 +1,18 @@
 package com.prgrms.prolog.global.jwt;
 
+import static org.springframework.http.HttpStatus.*;
+
+import java.io.IOException;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.prolog.global.dto.ErrorResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,15 +24,18 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint { /
 
 	private static final String ERROR_LOG_MESSAGE = "[ERROR] {} : {}";
 
-	// private final ObjectMapper objectMapper;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response,
-		AuthenticationException authException) {
+		AuthenticationException authException) throws IOException {
 		log.info(ERROR_LOG_MESSAGE, authException.getClass().getSimpleName(), authException.getMessage());
-		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setStatus(UNAUTHORIZED.value());
 		response.setContentType("application/json");
 		response.setCharacterEncoding("UTF-8");
-		// response.getWriter().write(objectMapper.writeValueAsString(ERROR_MESSAGE));
+		response.getWriter()
+			.write(objectMapper.writeValueAsString(
+				ErrorResponse.of(UNAUTHORIZED.name(), authException.getMessage()))
+			);
 	}
 }

--- a/src/main/java/com/prgrms/prolog/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/prgrms/prolog/global/jwt/JwtTokenProvider.java
@@ -16,6 +16,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Component
 public final class JwtTokenProvider {
@@ -46,7 +47,7 @@ public final class JwtTokenProvider {
 			.withIssuer(issuer)
 			.withIssuedAt(now)
 			.withExpiresAt(new Date(now.getTime() + expirySeconds * 1_000L))
-			.withClaim("email", claims.getEmail())
+			.withClaim("userId", claims.getUserId())
 			.withClaim("role", claims.getRole())
 			.sign(algorithm);
 	}
@@ -55,19 +56,20 @@ public final class JwtTokenProvider {
 		return new Claims(jwtVerifier.verify(token));
 	}
 
+	@ToString
 	@Getter
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Claims {
 
-		private String email;
+		private Long userId;
 		private String role;
 		private Date iat;
 		private Date exp;
 
 		protected Claims(DecodedJWT decodedJwt) {
-			Claim email = decodedJwt.getClaim("email");
-			if (!email.isNull()) {
-				this.email = email.asString();
+			Claim id = decodedJwt.getClaim("userId");
+			if (!id.isNull()) {
+				this.userId = id.asLong();
 			}
 			Claim role = decodedJwt.getClaim("role");
 			if (!role.isNull()) {
@@ -77,21 +79,11 @@ public final class JwtTokenProvider {
 			this.exp = decodedJwt.getExpiresAt();
 		}
 
-		public static Claims from(String email, String role) {
+		public static Claims from(Long userId, String role) {
 			Claims claims = new Claims();
-			claims.email = email;
+			claims.userId = userId;
 			claims.role = role;
 			return claims;
-		}
-
-		@Override
-		public String toString() {
-			return "Claims{"
-				+ "email='" + email + '\''
-				+ ", role='" + role + '\''
-				+ ", iat=" + iat
-				+ ", exp=" + exp
-				+ '}';
 		}
 	}
 }

--- a/src/main/java/com/prgrms/prolog/global/oauth/OAuthAuthenticationSuccessHandler.java
+++ b/src/main/java/com/prgrms/prolog/global/oauth/OAuthAuthenticationSuccessHandler.java
@@ -12,7 +12,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.prgrms.prolog.domain.user.dto.UserDto.UserProfile;
+import com.prgrms.prolog.domain.user.dto.UserDto.UserInfo;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,8 +36,8 @@ public class OAuthAuthenticationSuccessHandler implements AuthenticationSuccessH
 		Object principal = authentication.getPrincipal();
 
 		if (principal instanceof OAuth2User oauth2User) {
-			UserProfile userProfile = OAuthProvider.toUserProfile(oauth2User, providerName);
-			String accessToken = oauthService.login(userProfile);
+			UserInfo userInfo = OAuthProvider.toUserProfile(oauth2User, providerName);
+			String accessToken = oauthService.login(userInfo);
 			setResponse(response, accessToken); // TODO: 헤더에 넣기
 		}
 	}

--- a/src/main/java/com/prgrms/prolog/global/oauth/OAuthProvider.java
+++ b/src/main/java/com/prgrms/prolog/global/oauth/OAuthProvider.java
@@ -12,16 +12,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class OAuthProvider {
 
-	public static UserProfile toUserProfile(OAuth2User oauth, String providerName) {
+	public static UserInfo toUserProfile(OAuth2User oauth, String providerName) {
 		Map<String, Object> response = oauth.getAttributes();
 		Map<String, Object> properties = oauth.getAttribute("properties");
 		Map<String, Object> account = oauth.getAttribute("kakao_account");
 
-		return UserProfile.builder()
+		return UserInfo.builder()
 			.email(String.valueOf(account.get("email")))
 			.nickName(String.valueOf(properties.get("nickname")))
 			.oauthId(String.valueOf(response.get("id")))
 			.provider(providerName)
+			.profileImgUrl(String.valueOf(properties.get("profile_image")))
 			.build();
 	}
 }

--- a/src/main/java/com/prgrms/prolog/global/oauth/OAuthService.java
+++ b/src/main/java/com/prgrms/prolog/global/oauth/OAuthService.java
@@ -20,8 +20,9 @@ public class OAuthService {
 	private final UserService userService;
 
 	@Transactional
-	public String login(UserProfile userProfile) {
-		UserInfo user = userService.login(userProfile);
-		return jwtTokenProvider.createAccessToken(Claims.from(user.email(), "ROLE_USER"));
+	public String login(UserInfo userInfo) {
+		Long userId = userService.signUp(userInfo).id();
+		return jwtTokenProvider.createAccessToken(
+			Claims.from(userId,"ROLE_USER"));
 	}
 }

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -2,7 +2,7 @@
 jwt:
   issuer: ${JWT_ISSUER}
   secret-key: ${JWT_SECRET_KEY}
-  expiry-seconds: 60
+  expiry-seconds: 1200
 
 spring:
   security:

--- a/src/main/resources/db/migration/V2__add_profile_img_url.sql
+++ b/src/main/resources/db/migration/V2__add_profile_img_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD profile_img_url varchar(255) NULL AFTER email;

--- a/src/test/java/com/prgrms/prolog/config/JwtConfig.java
+++ b/src/test/java/com/prgrms/prolog/config/JwtConfig.java
@@ -1,0 +1,20 @@
+package com.prgrms.prolog.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.prgrms.prolog.global.jwt.JwtTokenProvider;
+
+@TestConfiguration
+public class JwtConfig {
+
+	@Bean
+	public JwtTokenProvider jwtTokenProvider(
+		@Value("${jwt.issuer}") String issuer,
+		@Value("${jwt.secret-key}") String secretKey,
+		@Value("${jwt.expiry-seconds}") int expirySeconds
+	) {
+		return new JwtTokenProvider(issuer,secretKey,expirySeconds);
+	}
+}

--- a/src/test/java/com/prgrms/prolog/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/comment/repository/CommentRepositoryTest.java
@@ -37,10 +37,12 @@ class CommentRepositoryTest {
 	void joinUserByCommentIdTest() {
 		// given
 		User user = userRepository.save(USER);
-		Post post = postRepository.save(POST);
+		Post post = getPost();
+		post.setUser(user);
+		Post savedPost = postRepository.save(post);
 		Comment comment = Comment.builder()
 			.user(user)
-			.post(post)
+			.post(savedPost)
 			.content("댓글 내용")
 			.build();
 		Comment savedComment = commentRepository.save(comment);

--- a/src/test/java/com/prgrms/prolog/domain/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/comment/service/CommentServiceImplTest.java
@@ -24,9 +24,9 @@ class CommentServiceImplTest {
 	@DisplayName("댓글 저장에 성공한다.")
 	void saveTest() {
 		// given
-		when(commentService.save(any(), anyString(), anyLong())).thenReturn(1L);
+		when(commentService.save(any(), anyLong(), anyLong())).thenReturn(1L);
 		// when
-		Long commentId = commentService.save(CREATE_COMMENT_REQUEST, USER.getEmail(), 1L);
+		Long commentId = commentService.save(CREATE_COMMENT_REQUEST, USER_ID, 1L);
 		// then
 		assertThat(commentId).isEqualTo(1L);
 	}
@@ -34,8 +34,8 @@ class CommentServiceImplTest {
 	@Test
 	@DisplayName("댓글 수정에 성공한다.")
 	void updateTest() {
-		when(commentService.update(any(), anyString(), anyLong())).thenReturn(1L);
-		Long commentId = commentService.update(UPDATE_COMMENT_REQUEST, USER.getEmail(), 1L);
+		when(commentService.update(any(), anyLong(), anyLong())).thenReturn(1L);
+		Long commentId = commentService.update(UPDATE_COMMENT_REQUEST, USER_ID, 1L);
 		assertThat(commentId).isEqualTo(1L);
 	}
 
@@ -43,10 +43,10 @@ class CommentServiceImplTest {
 	@DisplayName("존재하지 않는 댓글을 수정하면 예외가 발생한다.")
 	void updateNotExistsCommentThrowExceptionTest() {
 		// given
-		when(commentService.update(UPDATE_COMMENT_REQUEST, USER.getEmail(), 0L)).thenThrow(
+		when(commentService.update(UPDATE_COMMENT_REQUEST, USER_ID, 0L)).thenThrow(
 			new IllegalArgumentException());
 		// when & then
-		assertThatThrownBy(() -> commentService.update(UPDATE_COMMENT_REQUEST, USER.getEmail(), 0L)).isInstanceOf(
+		assertThatThrownBy(() -> commentService.update(UPDATE_COMMENT_REQUEST, USER_ID, 0L)).isInstanceOf(
 			IllegalArgumentException.class);
 	}
 
@@ -54,11 +54,12 @@ class CommentServiceImplTest {
 	@DisplayName("존재하지 않는 회원이 댓글을 저장하면 예외가 발생한다.")
 	void updateCommentByNotExistsUserThrowExceptionTest() {
 		// given
+
 		final UpdateCommentRequest updateCommentRequest = new UpdateCommentRequest("댓글 내용");
-		when(commentService.update(updateCommentRequest, "존재하지않는이메일@test.com", 1L)).thenThrow(
+		when(commentService.update(updateCommentRequest, UNSAVED_USER_ID, 1L)).thenThrow(
 			new IllegalArgumentException());
 		// when & then
-		assertThatThrownBy(() -> commentService.update(updateCommentRequest, "존재하지않는이메일@test.com", 1L)).isInstanceOf(
+		assertThatThrownBy(() -> commentService.update(updateCommentRequest, UNSAVED_USER_ID, 1L)).isInstanceOf(
 			IllegalArgumentException.class);
 	}
 
@@ -66,10 +67,10 @@ class CommentServiceImplTest {
 	@DisplayName("존재하지 않는 게시글에 댓글을 저장하면 예외가 발생한다.")
 	void saveCommentNotExistsPostThrowExceptionTest() {
 		// given
-		when(commentService.save(CREATE_COMMENT_REQUEST, USER.getEmail(), 0L)).thenThrow(
+		when(commentService.save(CREATE_COMMENT_REQUEST, USER_ID, 0L)).thenThrow(
 			new IllegalArgumentException());
 		// when & then
-		assertThatThrownBy(() -> commentService.save(CREATE_COMMENT_REQUEST, USER.getEmail(), 0L)).isInstanceOf(
+		assertThatThrownBy(() -> commentService.save(CREATE_COMMENT_REQUEST, USER_ID, 0L)).isInstanceOf(
 			IllegalArgumentException.class);
 	}
 

--- a/src/test/java/com/prgrms/prolog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/post/service/PostServiceTest.java
@@ -59,7 +59,7 @@ class PostServiceTest {
 	@DisplayName("게시물을 등록할 수 있다.")
 	void save_success() {
 		CreateRequest postRequest = new CreateRequest("테스트", "테스트 내용", true);
-		Long savePostId = postService.save(postRequest, USER_EMAIL);
+		Long savePostId = postService.save(postRequest, user.getId());
 		assertThat(savePostId).isNotNull();
 	}
 
@@ -70,7 +70,7 @@ class PostServiceTest {
 
 		CreateRequest postRequest = new CreateRequest("테스트", "테스트 내용", true);
 
-		assertThatThrownBy(() -> postService.save(postRequest, notExistEmail))
+		assertThatThrownBy(() -> postService.save(postRequest, USER_ID))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 

--- a/src/test/java/com/prgrms/prolog/domain/user/Repository/UserRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/user/Repository/UserRepositoryTest.java
@@ -38,22 +38,8 @@ class UserRepositoryTest {
 	@Test
 	@DisplayName("저장된 유저 정보를 유저ID로 찾아 가져올 수 있다.")
 	void saveAndFindByIdTest() {
-		// given
-		// when
+		// given & when
 		Optional<User> foundUser = userRepository.findById(savedUser.getId());
-		// then
-		assertThat(foundUser).isPresent();
-		assertThat(foundUser.get())
-			.usingRecursiveComparison()
-			.isEqualTo(savedUser);
-	}
-
-	@Test
-	@DisplayName("이메일로 저장된 유저 정보를 조회할 수 있다.")
-	void findEmailTest() {
-		// given
-		// when
-		Optional<User> foundUser = userRepository.findByEmail(savedUser.getEmail());
 		// then
 		assertThat(foundUser).isPresent();
 		assertThat(foundUser.get())
@@ -65,8 +51,9 @@ class UserRepositoryTest {
 	@DisplayName("저장되지 않은 유저는 조회할 수 없다.")
 	void findFailTest() {
 		// given
+		Long unsavedUserId = 0L;
 		// when
-		Optional<User> foundUser = userRepository.findByEmail("unsavedUserEmail@test.com");
+		Optional<User> foundUser = userRepository.findById(unsavedUserId);
 		// then
 		assertThat(foundUser).isNotPresent();
 	}

--- a/src/test/java/com/prgrms/prolog/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/user/api/UserControllerTest.java
@@ -15,31 +15,34 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import com.prgrms.prolog.config.RestDocsConfig;
+import com.prgrms.prolog.domain.user.model.User;
 import com.prgrms.prolog.domain.user.repository.UserRepository;
 import com.prgrms.prolog.domain.user.service.UserServiceImpl;
-import com.prgrms.prolog.global.config.JpaConfig;
 import com.prgrms.prolog.global.jwt.JwtTokenProvider;
 
 @SpringBootTest
 @ExtendWith(RestDocumentationExtension.class)
-@Import({RestDocsConfig.class, JpaConfig.class})
+@Import(RestDocsConfig.class)
+@Transactional
 class UserControllerTest {
 
-	private static final JwtTokenProvider jwtTokenProvider = JWT_TOKEN_PROVIDER;
 	protected MockMvc mockMvc;
-
 	@Autowired
-	RestDocumentationResultHandler restDocs;
+	private JwtTokenProvider jwtTokenProvider;
+	@Autowired
+	private RestDocumentationResultHandler restDocs;
 	@Autowired
 	private UserServiceImpl userService;
 	@Autowired
@@ -59,24 +62,25 @@ class UserControllerTest {
 	@DisplayName("사용자는 자신의 프로필 정보를 확인할 수 있다")
 	void userPage() throws Exception {
 		// given
-		userRepository.save(USER);
-		Claims claims = Claims.from(USER_EMAIL, USER_ROLE);
+		User savedUser = userRepository.save(USER);
+		Claims claims = Claims.from(savedUser.getId(), USER_ROLE);
 		// when
 		mockMvc.perform(RestDocumentationRequestBuilders.get("/api/v1/user/me")
-					.header("token", jwtTokenProvider.createAccessToken(claims))
-				// .header(HttpHeaders.AUTHORIZATION, "token" + jwtTokenProvider.createAccessToken(claims))
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + jwtTokenProvider.createAccessToken(claims))
 			)
 			// then
 			.andExpectAll(
-				handler().methodName("myPage"),
+				handler().methodName("getMyProfile"),
 				status().isOk())
 			// docs
 			.andDo(restDocs.document(
 				responseFields(
+					fieldWithPath("id").type(NUMBER).description("ID"),
 					fieldWithPath("email").type(STRING).description("이메일"),
 					fieldWithPath("nickName").type(STRING).description("닉네임"),
 					fieldWithPath("introduce").type(STRING).description("한줄 소개"),
-					fieldWithPath("prologName").type(STRING).description("블로그 제목")
+					fieldWithPath("prologName").type(STRING).description("블로그 제목"),
+					fieldWithPath("profileImgUrl").type(STRING).description("프로필 이미지")
 				))
 			);
 	}

--- a/src/test/java/com/prgrms/prolog/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/user/service/UserServiceTest.java
@@ -12,9 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.prgrms.prolog.domain.user.dto.UserDto.UserInfo;
+import com.prgrms.prolog.domain.user.dto.UserDto.IdResponse;
 import com.prgrms.prolog.domain.user.dto.UserDto.UserProfile;
 import com.prgrms.prolog.domain.user.model.User;
 import com.prgrms.prolog.domain.user.repository.UserRepository;
@@ -25,6 +26,9 @@ class UserServiceTest {
 	@Mock
 	private UserRepository userRepository;
 
+	@Mock
+	private User userMock;
+
 	@InjectMocks
 	private UserServiceImpl userService; // 빈으로 등록해서 주입 받고 싶으면 어떻게 해야하나요? 구현체말고 인터페이스를 주입 받고 싶습니다!
 
@@ -33,73 +37,69 @@ class UserServiceTest {
 	class SignUpAndLogin {
 
 		@Test
-		@DisplayName("이메일로 사용자 정보를 조회할 수 있다")
+		@DisplayName("userId를 통해서 사용자 정보를 조회할 수 있다")
 		void findByEmailTest() {
-			// given
-			User user = getUser();
-			given(userRepository.findByEmail(USER_EMAIL)).willReturn(Optional.of(user));
-			// when
-			UserInfo foundUser = userService.findByEmail(USER_EMAIL);
-			// then
-			then(userRepository).should().findByEmail(USER_EMAIL);
-			assertThat(foundUser)
-				.hasFieldOrPropertyWithValue("email", user.getEmail())
-				.hasFieldOrPropertyWithValue("nickName", user.getNickName())
-				.hasFieldOrPropertyWithValue("introduce", user.getIntroduce())
-				.hasFieldOrPropertyWithValue("prologName", user.getPrologName());
+			try (MockedStatic<UserProfile> userProfile = mockStatic(UserProfile.class)) {
+
+				//given
+				given(userRepository.findById(USER_ID)).willReturn(Optional.of(USER));
+				given(UserProfile.toUserProfile(USER)).willReturn(USER_PROFILE);
+
+				// when
+				UserProfile foundUser = userService.findUserProfileByUserId(USER_ID);
+
+				// then
+				then(userRepository).should().findById(USER_ID);
+				assertThat(foundUser)
+					.hasFieldOrPropertyWithValue("email", USER_EMAIL)
+					.hasFieldOrPropertyWithValue("nickName", USER_NICK_NAME)
+					.hasFieldOrPropertyWithValue("introduce", USER_INTRODUCE)
+					.hasFieldOrPropertyWithValue("prologName", USER_PROLOG_NAME)
+					.hasFieldOrPropertyWithValue("profileImgUrl", USER_PROFILE_IMG_URL);
+			}
 		}
 
-		@DisplayName("이메일 정보에 일치하는 사용자가 없으면 NotFoundException")
+		@DisplayName("userId에 해당하는 사용자가 없으면 IllegalArgumentException")
 		@Test
 		void notFoundMatchUser() {
-			given(userRepository.findByEmail(any(String.class))).willReturn(Optional.empty());
-			String unsavedEmail = "unsaved@test.com";
-			assertThatThrownBy(() -> userService.findByEmail(unsavedEmail))
+			//given
+			Long unsavedUserId = 100L;
+			given(userRepository.findById(any(Long.class))).willReturn(Optional.empty());
+			//when & then
+			assertThatThrownBy(() -> userService.findUserProfileByUserId(unsavedUserId))
 				.isInstanceOf(IllegalArgumentException.class);
 		}
 	}
 
 	@Nested
-	@DisplayName("회원가입 및 로그인 #9")
-	class FindUserInfo {
+	@DisplayName("회원가입 #9")
+	class FindUserProfile {
 		@Test
-		@DisplayName("등록된 사용자라면 로그인할 수 있다.")
-		void loginTest() {
+		@DisplayName("등록된 사용자는 회원 가입 절차 없이 등록된 사용자 ID를 반환 받을 수 있다.")
+		void signUpTest() {
 			// given
-			User user = getUser();
-			UserProfile savedUserProfile = getUserProfile();
-			given(userRepository.findByEmail(any(String.class))).willReturn(Optional.of(user));
+			given(userRepository.findByProviderAndOauthId(PROVIDER,OAUTH_ID))
+				.willReturn(Optional.of(userMock));
+			given(userMock.getId()).willReturn(USER_ID);
 			// when
-			UserInfo foundUserInfo = userService.login(savedUserProfile);
+			IdResponse userId = userService.signUp(USER_INFO);
 			// then
-			then(userRepository).should().findByEmail(savedUserProfile.email());
-			assertThat(foundUserInfo)
-				.hasFieldOrPropertyWithValue("email", user.getEmail())
-				.hasFieldOrPropertyWithValue("email", savedUserProfile.email())
-				.hasFieldOrPropertyWithValue("nickName", user.getNickName())
-				.hasFieldOrPropertyWithValue("nickName", savedUserProfile.nickName())
-				.hasFieldOrPropertyWithValue("introduce", user.getIntroduce())
-				.hasFieldOrPropertyWithValue("prologName", user.getPrologName());
+			then(userRepository).should().findByProviderAndOauthId(PROVIDER,OAUTH_ID);
 		}
 
 		@Test
-		@DisplayName("등록되지 않은 사용자가 로그인하는 경우 자동으로 회원가입이 진행된다.")
+		@DisplayName("등록되지 않은 사용자는 자동으로 회원가입이 진행된다.")
 		void defaultSignUpTest() {
 			// given
-			User user = getUser();
-			UserProfile unsavedUserProfile = getUserProfile();
-			given(userRepository.findByEmail(any(String.class))).willReturn(Optional.empty());
-			given(userRepository.save(any(User.class))).willReturn(user);
+			given(userRepository.findByProviderAndOauthId(PROVIDER, OAUTH_ID))
+				.willReturn(Optional.empty());
+			given(userRepository.save(any(User.class))).willReturn(userMock);
+			given(userMock.getId()).willReturn(USER_ID);
 			// when
-			UserInfo foundUserInfo = userService.login(unsavedUserProfile);
+			IdResponse userId = userService.signUp(USER_INFO);
 			// then
-			then(userRepository).should().findByEmail(unsavedUserProfile.email());
+			then(userRepository).should().findByProviderAndOauthId(PROVIDER, OAUTH_ID);
 			then(userRepository).should().save(any(User.class));
-			assertThat(foundUserInfo)
-				.hasFieldOrPropertyWithValue("email", user.getEmail())
-				.hasFieldOrPropertyWithValue("nickName", user.getNickName())
-				.hasFieldOrPropertyWithValue("introduce", user.getIntroduce())
-				.hasFieldOrPropertyWithValue("prologName", user.getPrologName());
 		}
 	}
 }

--- a/src/test/java/com/prgrms/prolog/global/jwt/JwtAuthenticationTest.java
+++ b/src/test/java/com/prgrms/prolog/global/jwt/JwtAuthenticationTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class JwtAuthenticationTest {
 
@@ -17,11 +19,11 @@ class JwtAuthenticationTest {
 	void token() {
 		// given
 		JwtAuthentication jwtAuthentication
-			= new JwtAuthentication(token, USER_EMAIL);
+			= new JwtAuthentication(token, USER_ID);
 		// when & then
 		assertThat(jwtAuthentication)
 			.hasFieldOrPropertyWithValue("token", token)
-			.hasFieldOrPropertyWithValue("userEmail", USER_EMAIL);
+			.hasFieldOrPropertyWithValue("id", USER_ID);
 	}
 
 	@ParameterizedTest
@@ -29,18 +31,19 @@ class JwtAuthenticationTest {
 	@DisplayName("token은 null, 빈 값일 수 없다.")
 	void validateTokenTest(String inputToken) {
 		//given & when & then
-		assertThatThrownBy(() -> new JwtAuthentication(inputToken, USER_EMAIL))
+		assertThatThrownBy(() -> new JwtAuthentication(inputToken, USER_ID))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("토큰");
 	}
 
 	@ParameterizedTest
-	@NullAndEmptySource
-	@DisplayName("email은 null, 빈 값일 수 없다.")
-	void validateUserEmailTest(String inputUserEmail) {
+	@NullSource
+	@ValueSource(longs = {0L, -1L, -100L})
+	@DisplayName("userId는 null, 0 이하일 수 없다.")
+	void validateUserEmailTest(Long inputUserId) {
 		//given & when & then
-		assertThatThrownBy(() -> new JwtAuthentication(token, inputUserEmail))
+		assertThatThrownBy(() -> new JwtAuthentication(token, inputUserId))
 			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessageContaining("이메일");
+			.hasMessageContaining("ID");
 	}
 }

--- a/src/test/java/com/prgrms/prolog/global/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/prgrms/prolog/global/jwt/JwtTokenProviderTest.java
@@ -13,18 +13,23 @@ import com.prgrms.prolog.global.jwt.JwtTokenProvider.Claims;
 
 class JwtTokenProviderTest {
 
-	private static final JwtTokenProvider jwtTokenProvider = JWT_TOKEN_PROVIDER;
+	private static final String ISSUER = "issuer";
+	private static final String SECRET_KEY = "secretKey";
+	private static final int EXPIRY_SECONDS = 2;
+
+	private static final JwtTokenProvider jwtTokenProvider
+		= new JwtTokenProvider(ISSUER,SECRET_KEY,EXPIRY_SECONDS);
 
 	@Test
 	@DisplayName("토큰 생성 및 추출")
 	void createTokenAndVerifyToken() {
 		// given
-		String token = jwtTokenProvider.createAccessToken(Claims.from(USER_EMAIL, USER_ROLE)); // TODO: 추후에 리팩터링 고려
+		String token = jwtTokenProvider.createAccessToken(Claims.from(USER_ID, USER_ROLE));
 		// when
 		Claims claims = jwtTokenProvider.getClaims(token);
 		// then
 		assertAll(
-			() -> assertThat(claims.getEmail()).isEqualTo(USER_EMAIL),
+			() -> assertThat(claims.getUserId()).isEqualTo(USER_ID),
 			() -> assertThat(claims.getRole()).isEqualTo(USER_ROLE)
 		);
 	}
@@ -33,9 +38,9 @@ class JwtTokenProviderTest {
 	@DisplayName("유효 시간이 지난 토큰을 사용하면 예외가 발생한다.")
 	void validateToken_OverTime() throws InterruptedException {
 		// given
-		String token = jwtTokenProvider.createAccessToken(Claims.from(USER_EMAIL, USER_ROLE));
+		String token = jwtTokenProvider.createAccessToken(Claims.from(USER_ID, USER_ROLE));
 		// when
-		sleep(EXPIRY_SECONDS * 2000);
+		sleep(EXPIRY_SECONDS * 2000L);
 		// then
 		assertThatThrownBy(() -> jwtTokenProvider.getClaims(token))
 			.isInstanceOf(JWTVerificationException.class);
@@ -43,9 +48,9 @@ class JwtTokenProviderTest {
 
 	@Test
 	@DisplayName("유효하지 않은 토큰을 사용하면 예외가 발생한다.")
-	void validateToken_Invalid() {
+	void validateTokenByInvalid() {
 		// given
-		String token = "Invalid";
+		String token = "invalid";
 		// when & then
 		assertThatThrownBy(() -> jwtTokenProvider.getClaims(token))
 			.isInstanceOf(JWTVerificationException.class);
@@ -53,15 +58,13 @@ class JwtTokenProviderTest {
 
 	@Test
 	@DisplayName("올바르지 않은 시그니처로 검증 시 예외를 발생한다.")
-	void validateToken_WrongSign() {
+	void validateTokenByWrongSign() {
 		// given
-		JwtTokenProvider wongTokenProvider = new JwtTokenProvider(
-			ISSUER,
-			"S-Team",
-			0
-		);
+		String invalidSecretKey = "S-Team";
+		JwtTokenProvider wongTokenProvider
+			= new JwtTokenProvider(ISSUER, invalidSecretKey, EXPIRY_SECONDS);
 		//when
-		String token = wongTokenProvider.createAccessToken(Claims.from(USER_EMAIL, USER_ROLE));
+		String token = wongTokenProvider.createAccessToken(Claims.from(USER_ID, USER_ROLE));
 		//then
 		assertThatThrownBy(() -> jwtTokenProvider.getClaims(token))
 			.isInstanceOf(JWTVerificationException.class);

--- a/src/test/java/com/prgrms/prolog/utils/TestUtils.java
+++ b/src/test/java/com/prgrms/prolog/utils/TestUtils.java
@@ -2,22 +2,26 @@ package com.prgrms.prolog.utils;
 
 import com.prgrms.prolog.domain.comment.model.Comment;
 import com.prgrms.prolog.domain.post.model.Post;
-import com.prgrms.prolog.domain.user.dto.UserDto.UserInfo;
 import com.prgrms.prolog.domain.user.dto.UserDto.UserProfile;
+import com.prgrms.prolog.domain.user.dto.UserDto.UserInfo;
 import com.prgrms.prolog.domain.user.model.User;
-import com.prgrms.prolog.global.jwt.JwtTokenProvider;
 
 public class TestUtils {
 
 	// User Data
+	public static final Long USER_ID = 1L;
+	public static final Long UNSAVED_USER_ID = 0L;
 	public static final String USER_EMAIL = "dev@programmers.com";
 	public static final String USER_NICK_NAME = "머쓱이";
 	public static final String USER_INTRODUCE = "머쓱이에욤";
 	public static final String USER_PROLOG_NAME = "머쓱이의 prolog";
 	public static final String PROVIDER = "kakao";
 	public static final String OAUTH_ID = "kakao@123456789";
+	public static final String USER_PROFILE_IMG_URL = "http://kakao/defaultImg.jpg";
 	public static final User USER = getUser();
 	public static final Post POST = getPost();
+	public static final UserInfo USER_INFO = getUserInfo();
+	public static final UserProfile USER_PROFILE = getUserProfile();
 	public static final Comment COMMENT = getComment();
 	// Post & Comment Data
 	public static final String TITLE = "제목을 입력해주세요";
@@ -28,13 +32,8 @@ public class TestUtils {
 	public static final String OVER_SIZE_100 = "0" + "1234567890".repeat(10);
 	public static final String OVER_SIZE_255 = "012345" + "1234567890".repeat(25);
 	public static final String OVER_SIZE_65535 = "012345" + "1234567890".repeat(6553);
-	// JWT
-	public static final String ISSUER = "prgrms";
-	public static final String SECRET_KEY = "prgrmsbackenddevrteamprologkwonj";
-	public static final int EXPIRY_SECONDS = 2;
-
-	public static final JwtTokenProvider JWT_TOKEN_PROVIDER
-		= new JwtTokenProvider(ISSUER, SECRET_KEY, EXPIRY_SECONDS);
+	// Authentication
+	public static final String BEARER_TYPE = "Bearer ";
 
 	private TestUtils() {
 		/* no-op */
@@ -48,6 +47,7 @@ public class TestUtils {
 			.prologName(USER_PROLOG_NAME)
 			.provider(PROVIDER)
 			.oauthId(OAUTH_ID)
+			.profileImgUrl(USER_PROFILE_IMG_URL)
 			.build();
 	}
 
@@ -68,17 +68,25 @@ public class TestUtils {
 			.build();
 	}
 
-	public static UserProfile getUserProfile() {
-		return new UserProfile(
-			USER_EMAIL,
-			USER_NICK_NAME,
-			PROVIDER,
-			OAUTH_ID
-		);
+	public static UserInfo getUserInfo() {
+		return UserInfo.builder()
+			.email(USER_EMAIL)
+			.nickName(USER_NICK_NAME)
+			.provider(PROVIDER)
+			.oauthId(OAUTH_ID)
+			.profileImgUrl(USER_PROFILE_IMG_URL)
+			.build();
 	}
 
-	public static UserInfo getUserInfo() {
-		return new UserInfo(USER);
+	public static UserProfile getUserProfile() {
+		return UserProfile.builder()
+			.id(USER_ID)
+			.email(USER_EMAIL)
+			.nickName(USER_NICK_NAME)
+			.prologName(USER_PROLOG_NAME)
+			.introduce(USER_INTRODUCE)
+			.profileImgUrl(USER_PROFILE_IMG_URL)
+			.build();
 	}
 
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -25,4 +25,4 @@ spring:
 jwt:
   issuer: prgrms
   secret-key: prgrmsbackenddevrteamprologkwonj
-  expiry-seconds: 60
+  expiry-seconds: 3

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE users
 (
     id          bigint       NOT NULL PRIMARY KEY AUTO_INCREMENT,
     email       varchar(100) NOT NULL UNIQUE,
+    profile_img_url varchar(255) NULL,
     nick_name   varchar(100) NULL UNIQUE,
     introduce   varchar(100) NULL,
     prolog_name varchar(100) NOT NULL UNIQUE,


### PR DESCRIPTION
## 🌱 작업 사항
### JWT
- headerkey 변경 (token -> AUTHORIZATION Bearer 로 변경)
  -  Authorization Bearer는 관례적인 포맷이기 때문에 사용이 권장됩니다.
  - https://www.ssemi.net/what-is-the-bearer-authentication/ 
- payload(Claim) 변경 (email -> id)
  - email은 중복의 가능성이 있기 때문에 확장성 고려를 위해 변경하는 것이 좋습니다.
- 유효시간 1분 -> 20분 변경
### OAuth
- ProfileImgUrl 추가
  - 카카오에서 프로필 이미지도 받아오도록 설정
  - 엔티티에 필드 추가 및 flyway V2추가
 ### 테스트
 - JwtConfig 추가 (secretkey 변수화)  
## 🦄 관련 이슈
#66 