### PR TITLE
[#79] 게시글 태그 수정 리팩터링

### DIFF
--- a/src/main/java/com/prgrms/prolog/domain/post/model/Post.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/model/Post.java
@@ -1,6 +1,5 @@
 package com.prgrms.prolog.domain.post.model;
 
-import static javax.persistence.CascadeType.*;
 import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.*;
 
@@ -61,7 +60,7 @@ public class Post extends BaseEntity {
 	@OneToMany(mappedBy = "post")
 	private final List<Comment> comments = new ArrayList<>();
 
-	@OneToMany(mappedBy = "post", cascade = ALL)
+	@OneToMany(mappedBy = "post")
 	private final Set<PostTag> postTags = new HashSet<>();
 
 	@Builder
@@ -101,7 +100,7 @@ public class Post extends BaseEntity {
 		this.openStatus = updateRequest.openStatus();
 	}
 
-	public void addPostTagsFrom(List<PostTag> postTags) {
+	public void addPostTagsFrom(Set<PostTag> postTags) {
 		this.postTags.addAll(postTags);
 	}
 

--- a/src/main/java/com/prgrms/prolog/domain/post/service/PostService.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/service/PostService.java
@@ -7,9 +7,9 @@ import com.prgrms.prolog.domain.post.dto.PostRequest;
 import com.prgrms.prolog.domain.post.dto.PostResponse;
 
 public interface PostService {
-		public Long save(PostRequest.CreateRequest request, Long userId);
-		public PostResponse findById(Long postId);
-		public Page<PostResponse> findAll(Pageable pageable);
-		public PostResponse update(PostRequest.UpdateRequest update, Long userId, Long postId);
-		public void delete(Long id);
+	Long save(PostRequest.CreateRequest request, Long userId);
+	PostResponse findById(Long postId);
+	Page<PostResponse> findAll(Pageable pageable);
+	PostResponse update(PostRequest.UpdateRequest update, Long userId, Long postId);
+	void delete(Long id);
 }

--- a/src/main/java/com/prgrms/prolog/domain/posttag/model/PostTag.java
+++ b/src/main/java/com/prgrms/prolog/domain/posttag/model/PostTag.java
@@ -16,12 +16,10 @@ import com.prgrms.prolog.domain.roottag.model.RootTag;
 
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class PostTag {

--- a/src/main/java/com/prgrms/prolog/domain/posttag/repository/PostTagRepository.java
+++ b/src/main/java/com/prgrms/prolog/domain/posttag/repository/PostTagRepository.java
@@ -1,8 +1,9 @@
 package com.prgrms.prolog.domain.posttag.repository;
 
-import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -10,6 +11,7 @@ import com.prgrms.prolog.domain.posttag.model.PostTag;
 
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 
+	@Modifying
 	@Query("""
 		DELETE
 		FROM PostTag pt
@@ -18,7 +20,7 @@ public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 		""")
 	void deleteByPostIdAndRootTagIds(
 		@Param(value = "postId") Long postId,
-		@Param(value = "rootTagIds") List<Long> rootTagIds
+		@Param(value = "rootTagIds") Set<Long> rootTagIds
 	);
 
 	@Query("""
@@ -27,5 +29,5 @@ public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 		LEFT JOIN FETCH pt.rootTag
 		WHERE pt.post.id = :postId
 		""")
-	List<PostTag> joinPostTagFindByPostId(@Param(value = "postId") Long postId);
+	Set<PostTag> joinRootTagFindByPostId(@Param(value = "postId") Long postId);
 }

--- a/src/main/java/com/prgrms/prolog/domain/roottag/model/RootTag.java
+++ b/src/main/java/com/prgrms/prolog/domain/roottag/model/RootTag.java
@@ -18,12 +18,10 @@ import com.prgrms.prolog.domain.usertag.model.UserTag;
 
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class RootTag {

--- a/src/main/java/com/prgrms/prolog/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/model/User.java
@@ -1,7 +1,5 @@
 package com.prgrms.prolog.domain.user.model;
 
-import static javax.persistence.CascadeType.*;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -54,7 +52,7 @@ public class User extends BaseEntity {
 	private final List<Post> posts = new ArrayList<>();
 	@OneToMany(mappedBy = "user")
 	private final List<Comment> comments = new ArrayList<>();
-	@OneToMany(mappedBy = "user", cascade = ALL)
+	@OneToMany(mappedBy = "user")
 	private final Set<UserTag> userTags = new HashSet<>();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -143,10 +141,6 @@ public class User extends BaseEntity {
 
 	public boolean checkSameEmail(String email) {
 		return this.email.equals(email);
-	}
-
-	public void removeUserTag(UserTag userTag) {
-		this.userTags.remove(userTag);
 	}
 
 	public boolean checkSameUserId(Long userId) {

--- a/src/main/java/com/prgrms/prolog/domain/usertag/model/UserTag.java
+++ b/src/main/java/com/prgrms/prolog/domain/usertag/model/UserTag.java
@@ -17,12 +17,10 @@ import com.prgrms.prolog.domain.user.model.User;
 
 import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class UserTag {
@@ -62,9 +60,6 @@ public class UserTag {
 	public void decreaseCount(int count) {
 		Assert.isTrue(count >= 0, "exception.userTag.count.positive");
 		this.count -= count;
-		if (count == 0) {
-			this.user.removeUserTag(this);
-		}
 	}
 
 	private RootTag validateRootTag(RootTag rootTag) {
@@ -80,5 +75,9 @@ public class UserTag {
 	private Integer validateCount(Integer count) {
 		Assert.isTrue(count >= 0, "exception.userTag.count.positiveOrZero");
 		return count;
+	}
+
+	public boolean isCountZero() {
+		return this.count == 0;
 	}
 }

--- a/src/test/java/com/prgrms/prolog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/post/service/PostServiceTest.java
@@ -31,7 +31,7 @@ import com.prgrms.prolog.domain.user.repository.UserRepository;
 class PostServiceTest {
 
 	@Autowired
-	PostServiceImpl postService;
+	PostService postService;
 
 	@Autowired
 	UserRepository userRepository;
@@ -105,6 +105,7 @@ class PostServiceTest {
 		Set<String> findTags = findPostResponse.tags();
 
 		// then
+		System.out.println(findTags);
 		assertThat(findTags)
 			.containsExactlyInAnyOrderElementsOf(expectedTags);
 	}
@@ -157,13 +158,16 @@ class PostServiceTest {
 	@Test
 	@DisplayName("존재하는 게시물의 아이디로 게시물의 제목, 내용, 태그, 공개범위를 수정할 수 있다.")
 	void update_success() {
-		UpdateRequest updateRequest = new UpdateRequest("수정된 테스트", "수정된 테스트 내용", "#수정된 태그", true);
+		final CreateRequest createRequest = new CreateRequest("테스트 제목", "테스트 내용", "#테스트#test#test1#테 스트", true);
+		Long savedPost = postService.save(createRequest, user.getId());
 
-		PostResponse update = postService.update(updateRequest, user.getId(), post.getId());
+		final UpdateRequest updateRequest = new UpdateRequest("수정된 테스트", "수정된 테스트 내용", "#테스트#수정된 태그", true);
+		PostResponse updatedPostResponse = postService.update(updateRequest, user.getId(), savedPost);
 
-		assertThat(update)
+		assertThat(updatedPostResponse)
 			.hasFieldOrPropertyWithValue("title", updateRequest.title())
-			.hasFieldOrPropertyWithValue("content", updateRequest.content());
+			.hasFieldOrPropertyWithValue("content", updateRequest.content())
+			.hasFieldOrPropertyWithValue("tags", Set.of("테스트", "수정된 태그"));
 	}
 
 	@Test


### PR DESCRIPTION
## 🌱 작업 사항
- 게시글 수정시 태그 업데이트 메서드 리팩터링
  - 새로운 RootTag 존재시 저장한다.
  - 없어진 PostTag를 삭제한다.
    - UserTag 카운트를 줄인다.
      - UserTag 카운트가 0일시에 삭제한다.
  - 새로운 PostTag를 저장한다.
    - UserTag를 새로 저장하거나 카운트를 증가한다.

## 🦄 관련 이슈
close #79
