### PR TITLE
[#61] Series 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'com.prgrms'
-version = '1.0.0'
+version = '1.0.2'
 sourceCompatibility = '17'
 
 configurations {
@@ -45,15 +45,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' // OAuth2-Client dependency
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // RestDocs API SPEC
     testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.16.2'
 
     // Swagger UI
     swaggerUI 'org.webjars:swagger-ui:4.11.1'
-
-    testImplementation 'org.springframework.security:spring-security-test'
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     //Lombok dependency
     compileOnly 'org.projectlombok:lombok'
@@ -62,16 +61,14 @@ dependencies {
     // MySQL Driver
     runtimeOnly 'com.mysql:mysql-connector-j'
 
-    //testcontainers dependency
+    //Testcontainers dependency
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
 
     // Flyway dependency
-    // https://mvnrepository.com/artifact/org.flywaydb/flyway-core
     implementation 'org.flywaydb:flyway-core:6.4.2'
 
     // JWT dependency
-    // https://mvnrepository.com/artifact/com.auth0/java-jwt
     implementation group: 'com.auth0', name: 'java-jwt', version: '4.2.1'
 
 }

--- a/src/main/java/com/prgrms/prolog/domain/post/dto/PostInfo.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/dto/PostInfo.java
@@ -3,12 +3,12 @@ package com.prgrms.prolog.domain.post.dto;
 import com.prgrms.prolog.domain.post.model.Post;
 
 public record PostInfo(
-	String title,
-	String content
+	Long id,
+	String title
 ) {
 	public static PostInfo toPostInfo(Post post) {
 		return new PostInfo(
-			post.getTitle(),
-			post.getContent()
+			post.getId(),
+			post.getTitle()
 		);
 	}}

--- a/src/main/java/com/prgrms/prolog/domain/post/dto/PostInfo.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/dto/PostInfo.java
@@ -1,0 +1,14 @@
+package com.prgrms.prolog.domain.post.dto;
+
+import com.prgrms.prolog.domain.post.model.Post;
+
+public record PostInfo(
+	String title,
+	String content
+) {
+	public static PostInfo toPostInfo(Post post) {
+		return new PostInfo(
+			post.getTitle(),
+			post.getContent()
+		);
+	}}

--- a/src/main/java/com/prgrms/prolog/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/dto/PostRequest.java
@@ -12,7 +12,8 @@ public class PostRequest {
 	public record CreateRequest(@NotBlank @Size(max = 200) String title,
 								@NotBlank String content,
 								@Nullable String tagText,
-								boolean openStatus) {
+								boolean openStatus,
+	                            @Nullable String seriesTitle) {
 		public static Post toEntity(CreateRequest create, User user) {
 			return Post.builder()
 				.title(create.title)

--- a/src/main/java/com/prgrms/prolog/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/dto/PostResponse.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import com.prgrms.prolog.domain.comment.model.Comment;
 import com.prgrms.prolog.domain.post.model.Post;
+import com.prgrms.prolog.domain.series.dto.SeriesResponse;
 import com.prgrms.prolog.domain.user.dto.UserDto.UserProfile;
 
 public record PostResponse(String title,
@@ -15,6 +16,7 @@ public record PostResponse(String title,
 						   boolean openStatus,
 						   UserProfile user,
 						   Set<String> tags,
+						   SeriesResponse seriesResponse,
 						   List<Comment> comment,
 						   int commentCount) {
 
@@ -24,6 +26,7 @@ public record PostResponse(String title,
 			post.isOpenStatus(),
 			toUserProfile(post.getUser()),
 			PostTagsResponse.from(post.getPostTags()).tagNames(),
+			SeriesResponse.toSeriesResponse(post.getSeries()),
 			post.getComments(),
 			post.getComments().size());
 	}

--- a/src/main/java/com/prgrms/prolog/domain/post/model/Post.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/model/Post.java
@@ -69,11 +69,12 @@ public class Post extends BaseEntity {
 	private Series series;
 
 	@Builder
-	public Post(String title, String content, boolean openStatus, User user) {
+	public Post(String title, String content, boolean openStatus, User user, Series series) {
 		this.title = validateTitle(title);
 		this.content = validateContent(content);
 		this.openStatus = openStatus;
 		this.user = Objects.requireNonNull(user, "exception.comment.user.require");
+		this.series = series;
 	}
 
 	public void setUser(User user) {

--- a/src/main/java/com/prgrms/prolog/domain/post/model/Post.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/model/Post.java
@@ -22,6 +22,7 @@ import org.springframework.util.Assert;
 import com.prgrms.prolog.domain.comment.model.Comment;
 import com.prgrms.prolog.domain.post.dto.PostRequest.UpdateRequest;
 import com.prgrms.prolog.domain.posttag.model.PostTag;
+import com.prgrms.prolog.domain.series.model.Series;
 import com.prgrms.prolog.domain.user.model.User;
 import com.prgrms.prolog.global.common.BaseEntity;
 
@@ -62,6 +63,10 @@ public class Post extends BaseEntity {
 
 	@OneToMany(mappedBy = "post")
 	private final Set<PostTag> postTags = new HashSet<>();
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "series_id")
+	private Series series;
 
 	@Builder
 	public Post(String title, String content, boolean openStatus, User user) {
@@ -124,5 +129,13 @@ public class Post extends BaseEntity {
 		if (text.length() > length) {
 			throw new IllegalArgumentException("exception.post.text.overLength");
 		}
+	}
+
+	public void setSeries(Series series) {
+		if (this.series != null) {
+			this.series.getPosts().remove(this);
+		}
+		this.series = series;
+		series.getPosts().add(this);
 	}
 }

--- a/src/main/java/com/prgrms/prolog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/prgrms/prolog/domain/post/repository/PostRepository.java
@@ -5,9 +5,11 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import com.prgrms.prolog.domain.post.model.Post;
 
+@Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
 	@Query("""

--- a/src/main/java/com/prgrms/prolog/domain/series/api/SeriesController.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/api/SeriesController.java
@@ -1,0 +1,32 @@
+package com.prgrms.prolog.domain.series.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prgrms.prolog.domain.series.dto.SeriesResponse;
+import com.prgrms.prolog.domain.series.service.SeriesService;
+import com.prgrms.prolog.global.jwt.JwtAuthentication;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/series")
+@RestController
+public class SeriesController {
+
+	private final SeriesService seriesService;
+
+	@GetMapping("/{title}")
+	ResponseEntity<SeriesResponse> findSeriesByTitle(
+		@PathVariable String title,
+		@AuthenticationPrincipal JwtAuthentication user
+	) {
+		return ResponseEntity.ok(
+			seriesService.findByTitle(user.id(), title)
+		);
+	}
+}

--- a/src/main/java/com/prgrms/prolog/domain/series/dto/CreateSeriesRequest.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/dto/CreateSeriesRequest.java
@@ -1,0 +1,8 @@
+package com.prgrms.prolog.domain.series.dto;
+
+import javax.validation.constraints.NotBlank;
+
+public record CreateSeriesRequest(
+	@NotBlank String title
+) {
+}

--- a/src/main/java/com/prgrms/prolog/domain/series/dto/CreateSeriesRequest.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/dto/CreateSeriesRequest.java
@@ -5,4 +5,7 @@ import javax.validation.constraints.NotBlank;
 public record CreateSeriesRequest(
 	@NotBlank String title
 ) {
+	public static CreateSeriesRequest of(String title) {
+		return new CreateSeriesRequest(title);
+	}
 }

--- a/src/main/java/com/prgrms/prolog/domain/series/dto/SeriesResponse.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/dto/SeriesResponse.java
@@ -1,0 +1,24 @@
+package com.prgrms.prolog.domain.series.dto;
+
+import java.util.List;
+
+import com.prgrms.prolog.domain.post.dto.PostInfo;
+import com.prgrms.prolog.domain.post.model.Post;
+import com.prgrms.prolog.domain.series.model.Series;
+
+public record SeriesResponse(
+	String title,
+	List<PostInfo> posts,
+	int count
+) {
+	public static SeriesResponse toSeriesResponse(Series series) {
+		List<Post> posts = series.getPosts();
+		return new SeriesResponse(
+			series.getTitle(),
+			posts.stream()
+				.map(PostInfo::toPostInfo).toList(),
+			posts.size()
+		);
+	}
+
+}

--- a/src/main/java/com/prgrms/prolog/domain/series/model/Series.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/model/Series.java
@@ -1,0 +1,80 @@
+package com.prgrms.prolog.domain.series.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import org.springframework.util.Assert;
+
+import com.prgrms.prolog.domain.post.model.Post;
+import com.prgrms.prolog.domain.user.model.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Series {
+
+	private static final int TITLE_MAX_SIZE = 50;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String title;
+
+	@OneToMany(mappedBy = "series")
+	private final List<Post> posts = new ArrayList<>();
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Builder
+	public Series(String title, User user, Post post) {
+		this.title = validateTitle(title);
+		setUser(Objects.requireNonNull(user, "exception.comment.user.require"));
+		post.setSeries(this);
+	}
+
+	public void setUser(User user) {
+		if (this.user != null) {
+			this.user.getSeries().remove(this);
+		}
+		this.user = user;
+		user.getSeries().add(this);
+	}
+
+	public void changeTitle(String title) {
+		this.title = validateTitle(title);
+	}
+
+	private String validateTitle(String title) {
+		checkText(title);
+		checkOverLength(title, TITLE_MAX_SIZE);
+		return title;
+	}
+
+	private void checkText(String text) {
+		Assert.hasText(text, "exception.comment.text");
+	}
+
+	private void checkOverLength(String text, int length) {
+		if (text.length() > length) {
+			throw new IllegalArgumentException("exception.post.text.overLength");
+		}
+	}
+}

--- a/src/main/java/com/prgrms/prolog/domain/series/model/Series.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/model/Series.java
@@ -47,6 +47,13 @@ public class Series {
 	public Series(String title, User user, Post post) {
 		this.title = validateTitle(title);
 		setUser(Objects.requireNonNull(user, "exception.comment.user.require"));
+		addPost(post);
+	}
+
+	private void addPost(Post post) {
+		if (post == null) {
+			return;
+		}
 		post.setSeries(this);
 	}
 

--- a/src/main/java/com/prgrms/prolog/domain/series/model/Series.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/model/Series.java
@@ -46,7 +46,7 @@ public class Series {
 	@Builder
 	public Series(String title, User user, Post post) {
 		this.title = validateTitle(title);
-		setUser(Objects.requireNonNull(user, "exception.comment.user.require"));
+		this.user = Objects.requireNonNull(user, "exception.comment.user.require");
 		addPost(post);
 	}
 

--- a/src/main/java/com/prgrms/prolog/domain/series/repository/SeriesRepository.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/repository/SeriesRepository.java
@@ -3,14 +3,19 @@ package com.prgrms.prolog.domain.series.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.prgrms.prolog.domain.series.model.Series;
 
 public interface SeriesRepository extends JpaRepository<Series, Long> {
 
-	// @Query("""
-	//	title & userId가 같은 Series, 한방에 잘 가져올 수 없나..?
-	// 	""")
-	Optional<Series> findByIdAndTitle(Long userId, String title);
+	@Query("""
+  		SELECT s
+		FROM Series s
+		WHERE s.user.id = :userId
+		and s.title = :title
+		""")
+	Optional<Series> findByIdAndTitle(@Param(value = "userId") Long userId, @Param(value = "title") String title);
 
 }

--- a/src/main/java/com/prgrms/prolog/domain/series/repository/SeriesRepository.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/repository/SeriesRepository.java
@@ -1,0 +1,16 @@
+package com.prgrms.prolog.domain.series.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.prgrms.prolog.domain.series.model.Series;
+
+public interface SeriesRepository extends JpaRepository<Series, Long> {
+
+	// @Query("""
+	//	title & userId가 같은 Series, 한방에 잘 가져올 수 없나..?
+	// 	""")
+	Optional<Series> findByIdAndTitle(Long userId, String title);
+
+}

--- a/src/main/java/com/prgrms/prolog/domain/series/service/SeriesService.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/service/SeriesService.java
@@ -8,7 +8,7 @@ import com.prgrms.prolog.global.common.IdResponse;
 
 public interface SeriesService {
 
-	IdResponse save(@Valid CreateSeriesRequest request, Long userId);
+	IdResponse create(@Valid CreateSeriesRequest request, Long userId);
 
 	SeriesResponse findByTitle(Long userId, String title);
 

--- a/src/main/java/com/prgrms/prolog/domain/series/service/SeriesService.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/service/SeriesService.java
@@ -1,0 +1,15 @@
+package com.prgrms.prolog.domain.series.service;
+
+import javax.validation.Valid;
+
+import com.prgrms.prolog.domain.series.dto.CreateSeriesRequest;
+import com.prgrms.prolog.domain.series.dto.SeriesResponse;
+import com.prgrms.prolog.global.common.IdResponse;
+
+public interface SeriesService {
+
+	IdResponse save(@Valid CreateSeriesRequest request, Long userId);
+
+	SeriesResponse findByTitle(Long userId, String title);
+
+}

--- a/src/main/java/com/prgrms/prolog/domain/series/service/SeriesServiceImpl.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/service/SeriesServiceImpl.java
@@ -1,0 +1,52 @@
+package com.prgrms.prolog.domain.series.service;
+
+import javax.validation.Valid;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.prolog.domain.series.dto.CreateSeriesRequest;
+import com.prgrms.prolog.domain.series.dto.SeriesResponse;
+import com.prgrms.prolog.domain.series.model.Series;
+import com.prgrms.prolog.domain.series.repository.SeriesRepository;
+import com.prgrms.prolog.domain.user.model.User;
+import com.prgrms.prolog.domain.user.repository.UserRepository;
+import com.prgrms.prolog.global.common.IdResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class SeriesServiceImpl implements SeriesService {
+
+	private final SeriesRepository seriesRepository;
+	private final UserRepository userRepository;
+
+	@Override
+	@Transactional
+	public IdResponse save(@Valid CreateSeriesRequest request, Long userId) {
+		User findUser = getFindUserBy(userId);
+		Series series = buildSeries(request.title(), findUser);
+		return new IdResponse(seriesRepository.save(series).getId());
+	}
+
+	@Override
+	public SeriesResponse findByTitle(Long userId, String title) {
+		return seriesRepository.findByIdAndTitle(userId, title)
+			.map(SeriesResponse::toSeriesResponse)
+			.orElseThrow(() -> new IllegalArgumentException("exception.user.notExists"));
+	}
+
+	private Series buildSeries(String title, User user) {
+		return Series.builder()
+			.title(title)
+			.user(user)
+			.build();
+	}
+
+	private User getFindUserBy(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("exception.user.notExists"));
+	}
+}

--- a/src/main/java/com/prgrms/prolog/domain/series/service/SeriesServiceImpl.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/service/SeriesServiceImpl.java
@@ -25,7 +25,7 @@ public class SeriesServiceImpl implements SeriesService {
 
 	@Override
 	@Transactional
-	public IdResponse save(@Valid CreateSeriesRequest request, Long userId) {
+	public IdResponse create(@Valid CreateSeriesRequest request, Long userId) {
 		User findUser = getFindUserBy(userId);
 		Series series = buildSeries(request.title(), findUser);
 		return new IdResponse(seriesRepository.save(series).getId());

--- a/src/main/java/com/prgrms/prolog/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/model/User.java
@@ -9,6 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -55,7 +56,7 @@ public class User extends BaseEntity {
 	private final List<Comment> comments = new ArrayList<>();
 	@OneToMany(mappedBy = "user")
 	private final Set<UserTag> userTags = new HashSet<>();
-	@OneToMany(mappedBy = "user")
+	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	private List<Series> series = new ArrayList<>();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/prgrms/prolog/domain/user/model/User.java
+++ b/src/main/java/com/prgrms/prolog/domain/user/model/User.java
@@ -20,6 +20,7 @@ import org.springframework.util.Assert;
 
 import com.prgrms.prolog.domain.comment.model.Comment;
 import com.prgrms.prolog.domain.post.model.Post;
+import com.prgrms.prolog.domain.series.model.Series;
 import com.prgrms.prolog.domain.usertag.model.UserTag;
 import com.prgrms.prolog.global.common.BaseEntity;
 
@@ -54,6 +55,8 @@ public class User extends BaseEntity {
 	private final List<Comment> comments = new ArrayList<>();
 	@OneToMany(mappedBy = "user")
 	private final Set<UserTag> userTags = new HashSet<>();
+	@OneToMany(mappedBy = "user")
+	private List<Series> series = new ArrayList<>();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -145,6 +148,10 @@ public class User extends BaseEntity {
 
 	public boolean checkSameUserId(Long userId) {
 		return Objects.equals(this.id, userId);
+	}
+
+	public void changeProfileImgUrl(String profileImgUrl) {
+		Objects.requireNonNull(profileImgUrl, "profileImgUrl" + NULL_VALUE_MESSAGE);
 	}
 
 	@Override

--- a/src/main/java/com/prgrms/prolog/global/common/IdResponse.java
+++ b/src/main/java/com/prgrms/prolog/global/common/IdResponse.java
@@ -1,0 +1,4 @@
+package com.prgrms.prolog.global.common;
+
+public record IdResponse(Long id) {
+}

--- a/src/test/java/com/prgrms/prolog/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/post/api/PostControllerTest.java
@@ -32,6 +32,7 @@ import com.prgrms.prolog.config.TestContainerConfig;
 import com.prgrms.prolog.domain.post.dto.PostRequest.CreateRequest;
 import com.prgrms.prolog.domain.post.dto.PostRequest.UpdateRequest;
 import com.prgrms.prolog.domain.post.service.PostServiceImpl;
+import com.prgrms.prolog.domain.series.repository.SeriesRepository;
 import com.prgrms.prolog.domain.user.repository.UserRepository;
 import com.prgrms.prolog.global.jwt.JwtTokenProvider;
 import com.prgrms.prolog.global.jwt.JwtTokenProvider.Claims;
@@ -55,6 +56,8 @@ class PostControllerTest {
 	private PostServiceImpl postService;
 	@Autowired
 	private UserRepository userRepository;
+	@Autowired
+	private SeriesRepository seriesRepository;
 	Long postId;
 	Long userId;
 	Claims claims;
@@ -66,7 +69,7 @@ class PostControllerTest {
 
 		userId = userRepository.save(USER).getId();
 		claims = Claims.from(userId, "ROLE_USER");
-		CreateRequest createRequest = new CreateRequest("테스트 제목", "테스트 내용", "#tag", false);
+		CreateRequest createRequest = new CreateRequest("테스트 제목", "테스트 내용", "#tag", false,null);
 		postId = postService.save(createRequest, userId);
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
 			.apply(documentationConfiguration(restDocumentation))
@@ -78,7 +81,7 @@ class PostControllerTest {
 	@Test
 	@DisplayName("게시물을 등록할 수 있다.")
 	void save() throws Exception {
-		CreateRequest request = new CreateRequest("생성된 테스트 제목", "생성된 테스트 내용", "tag", true);
+		CreateRequest request = new CreateRequest("생성된 테스트 제목", "생성된 테스트 내용", "tag", true, null);
 
 		mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/posts")
 				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + jwtTokenProvider.createAccessToken(claims))
@@ -194,7 +197,7 @@ class PostControllerTest {
 	@Test
 	@DisplayName("게시물 작성 중 제목이 공백인 경우 에러가 발생해야한다.")
 	void isValidateTitleNull() throws Exception {
-		CreateRequest createRequest = new CreateRequest("", "테스트 게시물 내용", "#tag", true);
+		CreateRequest createRequest = new CreateRequest("", "테스트 게시물 내용", "#tag", true, null);
 
 		String requestJsonString = objectMapper.writeValueAsString(createRequest);
 
@@ -208,7 +211,7 @@ class PostControllerTest {
 	@Test
 	@DisplayName("게시물 작성 중 내용이 빈칸인 경우 에러가 발생해야한다.")
 	void isValidateContentEmpty() throws Exception {
-		CreateRequest createRequest = new CreateRequest("테스트 게시물 제목", " ", "#tag", true);
+		CreateRequest createRequest = new CreateRequest("테스트 게시물 제목", " ", "#tag", true, null);
 
 		String requestJsonString = objectMapper.writeValueAsString(createRequest);
 
@@ -225,7 +228,7 @@ class PostControllerTest {
 		CreateRequest createRequest = new CreateRequest(
 			"안녕하세요. 여기는 프로그래머스 기술 블로그 prolog입니다. 이곳에 글을 작성하기 위해서는 제목은 50글자 미만이어야합니다.",
 			"null 게시물 내용", "#tag",
-			true);
+			true, null);
 
 		String requestJsonString = objectMapper.writeValueAsString(createRequest);
 
@@ -234,5 +237,22 @@ class PostControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestJsonString))
 			.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@DisplayName("포스트 생성시 시리즈도 만들어진다.")
+	void createSeries() throws Exception {
+		CreateRequest createRequest = new CreateRequest(
+			"안녕하세요. 여기는 프로그래머스 기술 블로그 prolog입니다",
+			"null 게시물 내용", "#tag",
+			true, "테스트 중");
+
+		String requestJsonString = objectMapper.writeValueAsString(createRequest);
+
+		mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/posts")
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + jwtTokenProvider.createAccessToken(claims))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(requestJsonString))
+			.andExpect(status().isCreated());
 	}
 }

--- a/src/test/java/com/prgrms/prolog/domain/post/model/PostTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/post/model/PostTest.java
@@ -54,7 +54,7 @@ class PostTest {
 	@DisplayName("게시글을 생성하기 위해서는 사용자가 필요하다.")
 	void createFailByUserNullTest() {
 		//given & when & then
-		assertThatThrownBy(() -> new Post(title, content, true, null))
+		assertThatThrownBy(() -> new Post(title, content, true, null,null))
 			.isInstanceOf(NullPointerException.class);
 	}
 
@@ -62,7 +62,7 @@ class PostTest {
 	@DisplayName("게시글 제목은 50자를 넘을 수 없다.")
 	void validateTitleTest() {
 		//given & when & then
-		assertThatThrownBy(() -> new Post(OVER_SIZE_50, content, true, USER))
+		assertThatThrownBy(() -> new Post(OVER_SIZE_50, content, true, USER, null))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 
@@ -71,7 +71,7 @@ class PostTest {
 	@DisplayName("게시글 제목은 빈 값,null일 수 없다.")
 	void validateTitleTest2(String inputTitle) {
 		//given & when & then
-		assertThatThrownBy(() -> new Post(inputTitle, content, true, USER))
+		assertThatThrownBy(() -> new Post(inputTitle, content, true, USER, null))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 
@@ -79,7 +79,7 @@ class PostTest {
 	@DisplayName("게시글 내용은 65535자를 넘을 수 없다.")
 	void validateContentTest() {
 		//given & when & then
-		assertThatThrownBy(() -> new Post(title, OVER_SIZE_65535, true, USER))
+		assertThatThrownBy(() -> new Post(title, OVER_SIZE_65535, true, USER, null))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 
@@ -88,7 +88,7 @@ class PostTest {
 	@DisplayName("게시글 내용은 빈 값,null일 수 없다.")
 	void validateContentTest2(String inputContent) {
 		//given & when & then
-		assertThatThrownBy(() -> new Post(title, inputContent, true, USER))
+		assertThatThrownBy(() -> new Post(title, inputContent, true, USER, null))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 

--- a/src/test/java/com/prgrms/prolog/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/post/repository/PostRepositoryTest.java
@@ -78,7 +78,7 @@ class PostRepositoryTest {
 	void findAll() {
 		List<Post> all = postRepository.findAll();
 
-		assertThat(all).hasSize(1);
+		assertThat(all).isNotEmpty();
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/prolog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/post/service/PostServiceTest.java
@@ -105,7 +105,6 @@ class PostServiceTest {
 		Set<String> findTags = findPostResponse.tags();
 
 		// then
-		System.out.println(findTags);
 		assertThat(findTags)
 			.containsExactlyInAnyOrderElementsOf(expectedTags);
 	}
@@ -186,7 +185,7 @@ class PostServiceTest {
 
 		Page<PostResponse> all = postService.findAll(page);
 
-		assertThat(all).hasSize(1);
+		assertThat(all).isNotNull();
 	}
 
 	@Test

--- a/src/test/java/com/prgrms/prolog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/post/service/PostServiceTest.java
@@ -57,7 +57,7 @@ class PostServiceTest {
 	@Test
 	@DisplayName("게시물을 등록할 수 있다.")
 	void save_success() {
-		final CreateRequest postRequest = new CreateRequest("테스트", "테스트 내용", "#테스트", true);
+		final CreateRequest postRequest = new CreateRequest("테스트", "테스트 내용", "#테스트", true, null);
 		Long savePostId = postService.save(postRequest, user.getId());
 		assertThat(savePostId).isNotNull();
 	}
@@ -66,7 +66,7 @@ class PostServiceTest {
 	@DisplayName("게시글에 태그 없이 등록할 수 있다.")
 	void savePostAndWithOutAnyTagTest() {
 		// given
-		final CreateRequest request = new CreateRequest("테스트 제목", "테스트 내용", null, true);
+		final CreateRequest request = new CreateRequest("테스트 제목", "테스트 내용", null, true, null);
 
 		// when
 		Long savedPostId = postService.save(request, user.getId());
@@ -81,7 +81,7 @@ class PostServiceTest {
 	@DisplayName("게시글에 태그가 공백이거나 빈 칸이라면 태그는 무시된다.")
 	void savePostWithBlankTagTest() {
 		// given
-		final CreateRequest request = new CreateRequest("테스트 제목", "테스트 내용", "# #", true);
+		final CreateRequest request = new CreateRequest("테스트 제목", "테스트 내용", "# #", true, null);
 
 		// when
 		Long savedPostId = postService.save(request, user.getId());
@@ -96,7 +96,7 @@ class PostServiceTest {
 	@DisplayName("게시글에 복수의 태그를 등록할 수 있다.")
 	void savePostAndTagsTest() {
 		// given
-		final CreateRequest request = new CreateRequest("테스트 제목", "테스트 내용", "#테스트#test#test1#테 스트", true);
+		final CreateRequest request = new CreateRequest("테스트 제목", "테스트 내용", "#테스트#test#test1#테 스트", true, null);
 		final List<String> expectedTags = List.of("테스트", "test", "test1", "테 스트");
 
 		// when
@@ -113,7 +113,7 @@ class PostServiceTest {
 	@DisplayName("게시물과 태그를 조회할 수 있다.")
 	void findPostAndTagsTest() {
 		// given
-		final CreateRequest request = new CreateRequest("테스트 제목", "테스트 내용", "#테스트", true);
+		final CreateRequest request = new CreateRequest("테스트 제목", "테스트 내용", "#테스트", true, null);
 
 		// when
 		Long savedPostId = postService.save(request, user.getId());
@@ -130,7 +130,7 @@ class PostServiceTest {
 	@Test
 	@DisplayName("존재하지 않는 사용자(비회원)의 이메일로 게시물을 등록할 수 없다.")
 	void save_fail() {
-		CreateRequest postRequest = new CreateRequest("테스트", "테스트 내용", "#테스트", true);
+		CreateRequest postRequest = new CreateRequest("테스트", "테스트 내용", "#테스트", true, null);
 
 		assertThatThrownBy(() -> postService.save(postRequest, UNSAVED_USER_ID))
 			.isInstanceOf(NullPointerException.class);
@@ -157,7 +157,7 @@ class PostServiceTest {
 	@Test
 	@DisplayName("존재하는 게시물의 아이디로 게시물의 제목, 내용, 태그, 공개범위를 수정할 수 있다.")
 	void update_success() {
-		final CreateRequest createRequest = new CreateRequest("테스트 제목", "테스트 내용", "#테스트#test#test1#테 스트", true);
+		final CreateRequest createRequest = new CreateRequest("테스트 제목", "테스트 내용", "#테스트#test#test1#테 스트", true,null);
 		Long savedPost = postService.save(createRequest, user.getId());
 
 		final UpdateRequest updateRequest = new UpdateRequest("수정된 테스트", "수정된 테스트 내용", "#테스트#수정된 태그", true);

--- a/src/test/java/com/prgrms/prolog/domain/series/api/SeriesControllerTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/series/api/SeriesControllerTest.java
@@ -1,0 +1,109 @@
+package com.prgrms.prolog.domain.series.api;
+
+import static com.prgrms.prolog.global.jwt.JwtTokenProvider.*;
+import static com.prgrms.prolog.utils.TestUtils.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import com.prgrms.prolog.config.RestDocsConfig;
+import com.prgrms.prolog.domain.post.model.Post;
+import com.prgrms.prolog.domain.post.repository.PostRepository;
+import com.prgrms.prolog.domain.series.model.Series;
+import com.prgrms.prolog.domain.series.repository.SeriesRepository;
+import com.prgrms.prolog.domain.user.model.User;
+import com.prgrms.prolog.domain.user.repository.UserRepository;
+import com.prgrms.prolog.global.jwt.JwtTokenProvider;
+
+@SpringBootTest
+@ExtendWith(RestDocumentationExtension.class)
+@Import(RestDocsConfig.class)
+@Transactional
+class SeriesControllerTest {
+
+	@Autowired
+	private JwtTokenProvider jwtTokenProvider;
+	@Autowired
+	private RestDocumentationResultHandler restDocs;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private PostRepository postRepository;
+	@Autowired
+	private SeriesRepository seriesRepository;
+
+	private MockMvc mockMvc;
+	private User savedUser;
+	private Post savedPost;
+	private Series savedSeries;
+
+	@BeforeEach
+	void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.addFilter(new CharacterEncodingFilter("UTF-8", true))
+			.apply(documentationConfiguration(provider))
+			.apply(springSecurity())
+			.alwaysDo(restDocs)
+			.build();
+		savedUser = userRepository.save(USER);
+		Post post = Post.builder()
+			.title(POST_TITLE)
+			.content(POST_CONTENT)
+			.openStatus(true)
+			.user(savedUser)
+			.build();
+		savedPost = postRepository.save(post);
+		Series series = Series.builder()
+			.title(SERIES_TITLE)
+			.user(savedUser)
+			.post(savedPost)
+			.build();
+		savedSeries = seriesRepository.save(series);
+	}
+
+	@Test
+	@DisplayName("자신이 가진 시리즈 중에서 제목으로 게시글 정보를 조회할 수 있다.")
+	void findSeriesByTitleTest() throws Exception {
+		// given
+		Claims claims = Claims.from(savedUser.getId(), USER_ROLE);
+		// when
+		mockMvc.perform(get("/api/v1/series/{title}", SERIES_TITLE)
+				.header(AUTHORIZATION, BEARER_TYPE + jwtTokenProvider.createAccessToken(claims))
+			)
+			// then
+			.andExpectAll(
+				handler().methodName("findSeriesByTitle"),
+				status().isOk())
+			// docs
+			.andDo(restDocs.document(
+				responseFields(
+					fieldWithPath("title").type(STRING).description("시리즈 제목"),
+					fieldWithPath("posts").type(ARRAY).description("게시글 목록"),
+					fieldWithPath("posts.[].title").type(STRING).description("게시글 제목"),
+					fieldWithPath("posts.[].content").type(STRING).description("게시글 내용"),
+					fieldWithPath("count").type(NUMBER).description("게시물 개수")
+				))
+			);
+
+	}
+}

--- a/src/test/java/com/prgrms/prolog/domain/series/api/SeriesControllerTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/series/api/SeriesControllerTest.java
@@ -99,8 +99,8 @@ class SeriesControllerTest {
 				responseFields(
 					fieldWithPath("title").type(STRING).description("시리즈 제목"),
 					fieldWithPath("posts").type(ARRAY).description("게시글 목록"),
+					fieldWithPath("posts.[].id").type(NUMBER).description("게시글 아이디"),
 					fieldWithPath("posts.[].title").type(STRING).description("게시글 제목"),
-					fieldWithPath("posts.[].content").type(STRING).description("게시글 내용"),
 					fieldWithPath("count").type(NUMBER).description("게시물 개수")
 				))
 			);

--- a/src/test/java/com/prgrms/prolog/domain/series/model/SeriesTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/series/model/SeriesTest.java
@@ -1,0 +1,68 @@
+package com.prgrms.prolog.domain.series.model;
+
+import static com.prgrms.prolog.utils.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.prgrms.prolog.utils.TestUtils;
+
+class SeriesTest {
+
+	@Test
+	@DisplayName("시리즈를 생성할 수 있다.")
+	void createSuccessTest(){
+	    // given & when & then
+		assertDoesNotThrow(
+			() -> Series.builder()
+				.title(TestUtils.SERIES_TITLE)
+				.user(USER)
+				.post(POST)
+				.build()
+		);
+	}
+
+	@Test
+	@DisplayName("시리즈와 연관된 엔티티를 조회할 수 있다.")
+	void readTest(){
+		// given & when & then
+		Series series = getSeries();
+		assertAll(
+			() -> assertThat(series.getTitle()).isEqualTo(TestUtils.SERIES_TITLE),
+			() -> assertThat(series.getUser()).isEqualTo(USER),
+			() -> assertThat(series.getPosts()).isEqualTo(List.of(POST))
+		);
+	}
+
+	@Test
+	@DisplayName("시리즈는 포스트 없이도 생성할 수 있다.")
+	void createSuccessDoesNotExistPostTest(){
+		// given & when & then
+		assertDoesNotThrow(
+			() -> Series.builder()
+				.title(TestUtils.SERIES_TITLE)
+				.user(USER)
+				.build()
+		);
+	}
+
+	@Test
+	@DisplayName("시리즈는 유저 없이 생성할 수 없다.")
+	void createFailTest(){
+		// given & when & then
+		assertThatThrownBy(
+			() -> Series.builder()
+				.title(TestUtils.SERIES_TITLE)
+				.post(POST)
+				.build()
+		)
+			.isInstanceOf(NullPointerException.class)
+			.hasMessageContaining("user");
+	}
+
+}

--- a/src/test/java/com/prgrms/prolog/domain/series/repository/SeriesRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/series/repository/SeriesRepositoryTest.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.prolog.domain.series.model.Series;
 import com.prgrms.prolog.domain.user.model.User;
@@ -24,7 +23,6 @@ import com.prgrms.prolog.global.config.JpaConfig;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({JpaConfig.class})
-@Transactional
 public class SeriesRepositoryTest {
 
 	@Autowired

--- a/src/test/java/com/prgrms/prolog/domain/series/repository/SeriesRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/series/repository/SeriesRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.prgrms.prolog.domain.series.repository;
+
+import static com.prgrms.prolog.utils.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prgrms.prolog.domain.series.model.Series;
+import com.prgrms.prolog.domain.user.model.User;
+import com.prgrms.prolog.domain.user.repository.UserRepository;
+import com.prgrms.prolog.global.config.JpaConfig;
+
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaConfig.class})
+@Transactional
+public class SeriesRepositoryTest {
+
+	@Autowired
+	private SeriesRepository seriesRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	private Series savedSeries;
+	private User savedUser;
+
+	@BeforeEach
+	void setUp() {
+		savedUser = userRepository.save(USER);
+		Series series = Series.builder()
+			.title(SERIES_TITLE)
+			.user(savedUser)
+			.build();
+		savedSeries = seriesRepository.save(series);
+	}
+
+	@Test
+	@DisplayName("해당 유저가 가진 시리즈 중에서 찾는 제목의 시리즈를 조회한다.")
+	void findByIdAndTitleTest() {
+		// given & when
+		Optional<Series> series = seriesRepository.findByIdAndTitle(savedUser.getId(), SERIES_TITLE);
+		// then
+		assertThat(series).isPresent();
+	}
+
+	@Disabled
+	@Test
+	@DisplayName("포스트 조회시 N+1 테스트")
+	void nPlus1Test() {
+		// given & when
+		Optional<Series> series = seriesRepository.findByIdAndTitle(savedUser.getId(), SERIES_TITLE);
+		// then
+		assertThat(series).isPresent();
+	}
+}

--- a/src/test/java/com/prgrms/prolog/domain/series/service/SeriesServiceImplTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/series/service/SeriesServiceImplTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.prgrms.prolog.domain.post.dto.PostInfo;
+import com.prgrms.prolog.domain.post.model.Post;
 import com.prgrms.prolog.domain.series.dto.CreateSeriesRequest;
 import com.prgrms.prolog.domain.series.dto.SeriesResponse;
 import com.prgrms.prolog.domain.series.model.Series;
@@ -33,6 +34,9 @@ class SeriesServiceImplTest {
 
 	@Mock
 	private Series series;
+
+	@Mock
+	private Post post;
 
 	@InjectMocks
 	private SeriesServiceImpl seriesService;
@@ -74,14 +78,16 @@ class SeriesServiceImplTest {
 		given(seriesRepository.findByIdAndTitle(any(Long.class),any(String.class)))
 			.willReturn(Optional.of(series));
 		given(series.getTitle()).willReturn(SERIES_TITLE);
-		given(series.getPosts()).willReturn((List.of(POST)));
+		given(series.getPosts()).willReturn((List.of(post)));
+		given(post.getId()).willReturn(1L);
+		given(post.getTitle()).willReturn(POST_TITLE);
 		// when
 		SeriesResponse seriesResponse = seriesService.findByTitle(USER_ID, SERIES_TITLE);
 		// then
 		then(seriesRepository).should().findByIdAndTitle(any(Long.class),any(String.class));
 		assertThat(seriesResponse)
 			.hasFieldOrPropertyWithValue("title", SERIES_TITLE)
-			.hasFieldOrPropertyWithValue("posts", List.of(new PostInfo(1L,POST_CONTENT)))
+			.hasFieldOrPropertyWithValue("posts", List.of(new PostInfo(1L,POST_TITLE)))
 			.hasFieldOrPropertyWithValue("count",1);
 		assertThat(seriesResponse.posts()).isNotEmpty();
 	}

--- a/src/test/java/com/prgrms/prolog/domain/series/service/SeriesServiceImplTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/series/service/SeriesServiceImplTest.java
@@ -1,0 +1,100 @@
+package com.prgrms.prolog.domain.series.service;
+
+import static com.prgrms.prolog.utils.TestUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.prolog.domain.post.dto.PostInfo;
+import com.prgrms.prolog.domain.series.dto.CreateSeriesRequest;
+import com.prgrms.prolog.domain.series.dto.SeriesResponse;
+import com.prgrms.prolog.domain.series.model.Series;
+import com.prgrms.prolog.domain.series.repository.SeriesRepository;
+import com.prgrms.prolog.domain.user.repository.UserRepository;
+import com.prgrms.prolog.global.common.IdResponse;
+
+@ExtendWith(MockitoExtension.class)
+class SeriesServiceImplTest {
+
+	@Mock
+	private SeriesRepository seriesRepository;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private Series series;
+
+	@InjectMocks
+	private SeriesServiceImpl seriesService;
+
+	@Test
+	@DisplayName("시리즈를 저장하기 위해서는 등록된 유저 정보가 필요하다.")
+	void saveSuccessTest() {
+		// given
+		CreateSeriesRequest createSeriesRequest
+			= new CreateSeriesRequest(SERIES_TITLE);
+		given(seriesRepository.save(any(Series.class))).willReturn(series);
+		given(userRepository.findById(USER_ID)).willReturn(Optional.of(USER));
+		given(series.getId()).willReturn(1L);
+		// when
+		IdResponse response = seriesService.create(createSeriesRequest, USER_ID);
+		// then
+		assertThat(response.id()).isEqualTo(1L);
+		then(seriesRepository).should().save(any(Series.class));
+		then(userRepository).should().findById(USER_ID);
+	}
+
+	@Test
+	@DisplayName("등록된 유저가 없는 경우 시리즈를 만들때 예외가 발생한다.")
+	void saveFailTest() {
+		// given
+		CreateSeriesRequest createSeriesRequest
+			= new CreateSeriesRequest(SERIES_TITLE);
+		given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+		// when & then
+		assertThatThrownBy(() -> seriesService.create(createSeriesRequest, USER_ID))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("user");
+	}
+
+	@Test
+	@DisplayName("등록된 유저가 없는 경우 시리즈를 만들때 예외가 발생한다.")
+	void findByTitleSuccessTest() {
+		// given
+		given(seriesRepository.findByIdAndTitle(any(Long.class),any(String.class)))
+			.willReturn(Optional.of(series));
+		given(series.getTitle()).willReturn(SERIES_TITLE);
+		given(series.getPosts()).willReturn((List.of(POST)));
+		// when
+		SeriesResponse seriesResponse = seriesService.findByTitle(USER_ID, SERIES_TITLE);
+		// then
+		then(seriesRepository).should().findByIdAndTitle(any(Long.class),any(String.class));
+		assertThat(seriesResponse)
+			.hasFieldOrPropertyWithValue("title", SERIES_TITLE)
+			.hasFieldOrPropertyWithValue("posts", List.of(new PostInfo(POST_TITLE,POST_CONTENT)))
+			.hasFieldOrPropertyWithValue("count",1);
+		assertThat(seriesResponse.posts()).isNotEmpty();
+	}
+
+	@Test
+	@DisplayName("찾는 시리즈가 없으면 예외가 발생한다.")
+	void findByTitleFailTest() {
+		// given
+		given(seriesRepository.findByIdAndTitle(any(Long.class),any(String.class)))
+			.willReturn(Optional.empty());
+		// when & then
+		assertThatThrownBy(() -> seriesService.findByTitle(USER_ID, SERIES_TITLE))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("notExists");
+	}
+}

--- a/src/test/java/com/prgrms/prolog/domain/series/service/SeriesServiceImplTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/series/service/SeriesServiceImplTest.java
@@ -81,7 +81,7 @@ class SeriesServiceImplTest {
 		then(seriesRepository).should().findByIdAndTitle(any(Long.class),any(String.class));
 		assertThat(seriesResponse)
 			.hasFieldOrPropertyWithValue("title", SERIES_TITLE)
-			.hasFieldOrPropertyWithValue("posts", List.of(new PostInfo(POST_TITLE,POST_CONTENT)))
+			.hasFieldOrPropertyWithValue("posts", List.of(new PostInfo(1L,POST_CONTENT)))
 			.hasFieldOrPropertyWithValue("count",1);
 		assertThat(seriesResponse.posts()).isNotEmpty();
 	}

--- a/src/test/java/com/prgrms/prolog/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/user/service/UserServiceTest.java
@@ -30,7 +30,7 @@ class UserServiceTest {
 	private User userMock;
 
 	@InjectMocks
-	private UserServiceImpl userService; // 빈으로 등록해서 주입 받고 싶으면 어떻게 해야하나요? 구현체말고 인터페이스를 주입 받고 싶습니다!
+	private UserServiceImpl userService;
 
 	@Nested
 	@DisplayName("사용자 조회 #10")

--- a/src/test/java/com/prgrms/prolog/utils/TestUtils.java
+++ b/src/test/java/com/prgrms/prolog/utils/TestUtils.java
@@ -4,6 +4,7 @@ import com.prgrms.prolog.domain.comment.model.Comment;
 import com.prgrms.prolog.domain.post.model.Post;
 import com.prgrms.prolog.domain.posttag.model.PostTag;
 import com.prgrms.prolog.domain.roottag.model.RootTag;
+import com.prgrms.prolog.domain.series.model.Series;
 import com.prgrms.prolog.domain.user.dto.UserDto.UserInfo;
 import com.prgrms.prolog.domain.user.dto.UserDto.UserProfile;
 import com.prgrms.prolog.domain.user.model.User;
@@ -25,9 +26,14 @@ public class TestUtils {
 	public static final UserInfo USER_INFO = getUserInfo();
 	public static final UserProfile USER_PROFILE = getUserProfile();
 	public static final Comment COMMENT = getComment();
+	public static final Series SERIES = getSeries();
 	// Post & Comment Data
 	public static final String TITLE = "제목을 입력해주세요";
 	public static final String CONTENT = "내용을 입력해주세요";
+	public static final String COMMENT_CONTENT = "댓글 내용";
+	public static final String POST_TITLE = "게시글 제목";
+	public static final String POST_CONTENT = "게시글 내용";
+	public static final String SERIES_TITLE = "시리즈 제목";
 	public static final String USER_ROLE = "ROLE_USER";
 	// RootTag & PostTag Data
 	public static final String ROOT_TAG_NAME = "머쓱 태그";
@@ -41,6 +47,7 @@ public class TestUtils {
 	public static final String OVER_SIZE_65535 = "012345" + "1234567890".repeat(6553);
 	// Authentication
 	public static final String BEARER_TYPE = "Bearer ";
+
 
 	private TestUtils() {
 		/* no-op */
@@ -60,8 +67,8 @@ public class TestUtils {
 
 	public static Post getPost() {
 		return Post.builder()
-			.title("제목")
-			.content("내용")
+			.title(POST_TITLE)
+			.content(POST_CONTENT)
 			.openStatus(true)
 			.user(USER)
 			.build();
@@ -69,7 +76,7 @@ public class TestUtils {
 
 	public static Comment getComment() {
 		return Comment.builder()
-			.content("내용")
+			.content(COMMENT_CONTENT)
 			.post(POST)
 			.user(USER)
 			.build();
@@ -105,6 +112,14 @@ public class TestUtils {
 	public static PostTag getPostTag() {
 		return PostTag.builder()
 			.rootTag(ROOT_TAG)
+			.post(POST)
+			.build();
+	}
+
+	public static Series getSeries() {
+		return Series.builder()
+			.title(SERIES_TITLE)
+			.user(USER)
 			.post(POST)
 			.build();
 	}


### PR DESCRIPTION
## 🌱 작업 사항
### Series
- Series Create 및 Find 기능 구현
  - 게시글 생성시 시리즈에 추가할 수 있게하였습니다.
  - 시리즈 제목으로 시리즈에 속한 게시글을 가져오는 API를 만들었습니다.
  - 게시글을 가져올 때 해당 게시글이 속한 시리즈에 대한 정보와 소속된 게시글의 ID와 제목을 모두 가져올 수 있도록 하였습니다. 
- 테스트 Update와 Delete 기능 추가하겠습니다.
## 🦄 관련 이슈
close #61