### PR TITLE
테스트 코드 추상화 작업

### DIFF
--- a/src/main/java/com/prgrms/prolog/domain/series/api/SeriesController.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/api/SeriesController.java
@@ -26,7 +26,7 @@ public class SeriesController {
 		@AuthenticationPrincipal JwtAuthentication user
 	) {
 		return ResponseEntity.ok(
-			seriesService.findByTitle(user.id(), title)
+			seriesService.findSeriesByTitle(user.id(), title)
 		);
 	}
 }

--- a/src/main/java/com/prgrms/prolog/domain/series/service/SeriesService.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/service/SeriesService.java
@@ -10,10 +10,6 @@ public interface SeriesService {
 
 	IdResponse createSeries(@Valid CreateSeriesRequest request, Long userId);
 
-	IdResponse changeSeries(@Valid UpdateSeriesRequest request, Long postId, Long userId);
-
 	SeriesResponse findSeriesByTitle(Long userId, String title);
-
-	void deleteSeries(Long userId, String title);
 
 }

--- a/src/main/java/com/prgrms/prolog/domain/series/service/SeriesService.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/service/SeriesService.java
@@ -8,8 +8,12 @@ import com.prgrms.prolog.global.common.IdResponse;
 
 public interface SeriesService {
 
-	IdResponse create(@Valid CreateSeriesRequest request, Long userId);
+	IdResponse createSeries(@Valid CreateSeriesRequest request, Long userId);
 
-	SeriesResponse findByTitle(Long userId, String title);
+	IdResponse changeSeries(@Valid UpdateSeriesRequest request, Long postId, Long userId);
+
+	SeriesResponse findSeriesByTitle(Long userId, String title);
+
+	void deleteSeries(Long userId, String title);
 
 }

--- a/src/main/java/com/prgrms/prolog/domain/series/service/SeriesServiceImpl.java
+++ b/src/main/java/com/prgrms/prolog/domain/series/service/SeriesServiceImpl.java
@@ -25,14 +25,14 @@ public class SeriesServiceImpl implements SeriesService {
 
 	@Override
 	@Transactional
-	public IdResponse create(@Valid CreateSeriesRequest request, Long userId) {
+	public IdResponse createSeries(@Valid CreateSeriesRequest request, Long userId) {
 		User findUser = getFindUserBy(userId);
 		Series series = buildSeries(request.title(), findUser);
 		return new IdResponse(seriesRepository.save(series).getId());
 	}
 
 	@Override
-	public SeriesResponse findByTitle(Long userId, String title) {
+	public SeriesResponse findSeriesByTitle(Long userId, String title) {
 		return seriesRepository.findByIdAndTitle(userId, title)
 			.map(SeriesResponse::toSeriesResponse)
 			.orElseThrow(() -> new IllegalArgumentException("exception.user.notExists"));

--- a/src/test/java/com/prgrms/prolog/base/ControllerTest.java
+++ b/src/test/java/com/prgrms/prolog/base/ControllerTest.java
@@ -1,0 +1,71 @@
+package com.prgrms.prolog.base;
+
+import static com.prgrms.prolog.global.jwt.JwtTokenProvider.*;
+import static com.prgrms.prolog.utils.TestUtils.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prgrms.prolog.config.RestDocsConfig;
+import com.prgrms.prolog.config.TestContainerConfig;
+import com.prgrms.prolog.domain.user.model.User;
+import com.prgrms.prolog.domain.user.repository.UserRepository;
+import com.prgrms.prolog.global.jwt.JwtTokenProvider;
+
+@Transactional
+@ExtendWith(RestDocumentationExtension.class)
+@Import({RestDocsConfig.class, TestContainerConfig.class})
+@SpringBootTest
+public abstract class ControllerTest {
+
+	@Autowired
+	protected RestDocumentationResultHandler restDocs;
+
+	@Autowired
+	protected ObjectMapper objectMapper;
+
+	@Autowired
+	protected JwtTokenProvider jwtTokenProvider;
+
+	@Autowired
+	protected UserRepository userRepository;
+
+	protected MockMvc mockMvc;
+	protected User savedUser;
+	protected Long savedUserId;
+	protected String ACCESS_TOKEN;
+
+	@BeforeEach
+	void setUpRestDocs(WebApplicationContext webApplicationContext,
+		RestDocumentationContextProvider restDocumentation) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+			.addFilter(new CharacterEncodingFilter("UTF-8", true))
+			.apply(documentationConfiguration(restDocumentation))
+			.apply(springSecurity())
+			.alwaysDo(restDocs)
+			.build();
+	}
+
+	@BeforeEach
+	void setUpLogin() {
+		savedUser = userRepository.save(USER);
+		Claims claims = Claims.from(savedUser.getId(), "ROLE_USER");
+		ACCESS_TOKEN = jwtTokenProvider.createAccessToken(claims);
+		savedUserId = savedUser.getId();
+	}
+
+}

--- a/src/test/java/com/prgrms/prolog/base/RepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/base/RepositoryTest.java
@@ -1,0 +1,101 @@
+package com.prgrms.prolog.base;
+
+import static com.prgrms.prolog.utils.TestUtils.*;
+import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.prgrms.prolog.config.TestContainerConfig;
+import com.prgrms.prolog.domain.comment.model.Comment;
+import com.prgrms.prolog.domain.comment.repository.CommentRepository;
+import com.prgrms.prolog.domain.like.model.Like;
+import com.prgrms.prolog.domain.like.repository.LikeRepository;
+import com.prgrms.prolog.domain.post.model.Post;
+import com.prgrms.prolog.domain.post.repository.PostRepository;
+import com.prgrms.prolog.domain.roottag.repository.RootTagRepository;
+import com.prgrms.prolog.domain.series.model.Series;
+import com.prgrms.prolog.domain.series.repository.SeriesRepository;
+import com.prgrms.prolog.domain.user.model.User;
+import com.prgrms.prolog.domain.user.repository.UserRepository;
+import com.prgrms.prolog.global.config.JpaConfig;
+
+@AutoConfigureTestDatabase(replace = NONE)
+@Import({JpaConfig.class, TestContainerConfig.class})
+@DataJpaTest
+public abstract class RepositoryTest {
+
+	@Autowired
+	protected UserRepository userRepository;
+
+	@Autowired
+	protected PostRepository postRepository;
+
+	@Autowired
+	protected CommentRepository commentRepository;
+
+	@Autowired
+	protected SeriesRepository seriesRepository;
+
+	@Autowired
+	protected LikeRepository likeRepository;
+
+	@Autowired
+	protected RootTagRepository rootTagRepository;
+
+	protected User savedUser;
+	protected Post savedPost;
+	protected Comment savedComment;
+	protected Series savedSeries;
+	protected Like savedLike;
+
+	@BeforeEach
+	void setUpEntity() {
+		// 유저
+		User user = User.builder()
+			.email(USER_EMAIL)
+			.nickName(USER_NICK_NAME)
+			.introduce(USER_INTRODUCE)
+			.prologName(USER_PROLOG_NAME)
+			.provider(PROVIDER)
+			.oauthId(OAUTH_ID)
+			.profileImgUrl(USER_PROFILE_IMG_URL)
+			.build();
+		savedUser = userRepository.save(user);
+
+		//게시글
+		Post post = Post.builder()
+			.title(POST_TITLE)
+			.content(POST_CONTENT)
+			.openStatus(true)
+			.user(savedUser)
+			.build();
+		savedPost = postRepository.save(post);
+
+		// 댓글
+		Comment comment = Comment.builder()
+			.user(savedUser)
+			.post(savedPost)
+			.content(COMMENT_CONTENT)
+			.build();
+		savedComment = commentRepository.save(comment);
+
+		// 시리즈
+		Series series = Series.builder()
+			.title(SERIES_TITLE)
+			.user(savedUser)
+			.build();
+		savedSeries = seriesRepository.save(series);
+		post.setSeries(savedSeries);
+
+		// 좋아요
+		Like like = Like.builder()
+			.user(savedUser)
+			.post(savedPost)
+			.build();
+		savedLike = likeRepository.save(like);
+	}
+}

--- a/src/test/java/com/prgrms/prolog/base/ServiceTest.java
+++ b/src/test/java/com/prgrms/prolog/base/ServiceTest.java
@@ -1,0 +1,43 @@
+package com.prgrms.prolog.base;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.prgrms.prolog.domain.like.model.Like;
+import com.prgrms.prolog.domain.like.repository.LikeRepository;
+import com.prgrms.prolog.domain.post.model.Post;
+import com.prgrms.prolog.domain.post.repository.PostRepository;
+import com.prgrms.prolog.domain.series.model.Series;
+import com.prgrms.prolog.domain.series.repository.SeriesRepository;
+import com.prgrms.prolog.domain.user.model.User;
+import com.prgrms.prolog.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class ServiceTest {
+
+	@Mock
+	protected UserRepository userRepository;
+
+	@Mock
+	protected PostRepository postRepository;
+
+	@Mock
+	protected SeriesRepository seriesRepository;
+
+	@Mock
+	protected LikeRepository likeRepository;
+
+	@Mock
+	protected User user;
+
+	@Mock
+	protected Post post;
+
+	@Mock
+	protected Series series;
+
+	@Mock
+	protected Like like;
+
+}

--- a/src/test/java/com/prgrms/prolog/config/TestContainerConfig.java
+++ b/src/test/java/com/prgrms/prolog/config/TestContainerConfig.java
@@ -14,12 +14,12 @@ public class TestContainerConfig {
 		.withDatabaseName("test");
 
 	@BeforeAll
-	static void beforeAll() {
+	public static void beforeAll() {
 		MY_SQL_CONTAINER.start();
 	}
 
 	@AfterAll
-	static void afterAll() {
+	public static void afterAll() {
 		MY_SQL_CONTAINER.stop();
 	}
 }

--- a/src/test/java/com/prgrms/prolog/domain/comment/api/CommentControllerTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/comment/api/CommentControllerTest.java
@@ -2,77 +2,27 @@ package com.prgrms.prolog.domain.comment.api;
 
 import static com.prgrms.prolog.utils.TestUtils.*;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.context.WebApplicationContext;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.prgrms.prolog.config.RestDocsConfig;
+import com.prgrms.prolog.base.ControllerTest;
 import com.prgrms.prolog.domain.comment.dto.CommentDto;
 import com.prgrms.prolog.domain.comment.service.CommentService;
-import com.prgrms.prolog.domain.user.repository.UserRepository;
-import com.prgrms.prolog.global.jwt.JwtTokenProvider;
-import com.prgrms.prolog.global.jwt.JwtTokenProvider.Claims;
 import com.prgrms.prolog.utils.TestUtils;
 
-@SpringBootTest
-@ExtendWith(RestDocumentationExtension.class)
-@Import(RestDocsConfig.class)
-@Transactional
-class CommentControllerTest {
-
-	@Autowired
-	RestDocumentationResultHandler restDocs;
-
-	MockMvc mockMvc;
+class CommentControllerTest extends ControllerTest {
 
 	@MockBean
 	CommentService commentService;
 
-	@Autowired
-	ObjectMapper objectMapper;
-
-	@Autowired
-	UserRepository userRepository;
-
-	@Autowired
-	private JwtTokenProvider jwtTokenProvider;
-
-	Long savedUserId ;
-
-	@BeforeEach
-	void setUpRestDocs(WebApplicationContext webApplicationContext,
-		RestDocumentationContextProvider restDocumentation) {
-		this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-			.apply(documentationConfiguration(restDocumentation))
-			.alwaysDo(restDocs)
-			.apply(springSecurity())
-			.build();
-	}
-
 	@Test
 	void commentSaveApiTest() throws Exception {
-		savedUserId = userRepository.save(USER).getId();
-		Claims claims = Claims.from(savedUserId, USER_ROLE);
 		CommentDto.CreateCommentRequest createCommentRequest = new CommentDto.CreateCommentRequest(
 			TestUtils.getComment().getContent());
 
@@ -80,7 +30,7 @@ class CommentControllerTest {
 			.thenReturn(1L);
 
 		mockMvc.perform(RestDocumentationRequestBuilders.post("/api/v1/posts/{post_id}/comments", 1L)
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + jwtTokenProvider.createAccessToken(claims))
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(createCommentRequest)))
 			.andExpect(status().isCreated())
@@ -94,8 +44,6 @@ class CommentControllerTest {
 
 	@Test
 	void commentUpdateApiTest() throws Exception {
-		savedUserId = userRepository.save(USER).getId();
-		Claims claims = Claims.from(savedUserId, USER_ROLE);
 		CommentDto.UpdateCommentRequest updateCommentRequest = new CommentDto.UpdateCommentRequest(
 			TestUtils.getComment().getContent() + "updated");
 
@@ -104,7 +52,7 @@ class CommentControllerTest {
 
 		// when
 		mockMvc.perform(RestDocumentationRequestBuilders.patch("/api/v1/posts/{post_id}/comments/{id}", 1, 1)
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + jwtTokenProvider.createAccessToken(claims))
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(updateCommentRequest)))
 			.andExpect(status().isOk())

--- a/src/test/java/com/prgrms/prolog/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/comment/repository/CommentRepositoryTest.java
@@ -1,52 +1,19 @@
 package com.prgrms.prolog.domain.comment.repository;
 
-import static com.prgrms.prolog.utils.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
+import com.prgrms.prolog.base.RepositoryTest;
 import com.prgrms.prolog.domain.comment.model.Comment;
-import com.prgrms.prolog.domain.post.model.Post;
-import com.prgrms.prolog.domain.post.repository.PostRepository;
-import com.prgrms.prolog.domain.user.model.User;
-import com.prgrms.prolog.domain.user.repository.UserRepository;
-import com.prgrms.prolog.global.config.JpaConfig;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = NONE)
-@Import({JpaConfig.class})
-class CommentRepositoryTest {
-
-	@Autowired
-	CommentRepository commentRepository;
-
-	@Autowired
-	PostRepository postRepository;
-
-	@Autowired
-	UserRepository userRepository;
+class CommentRepositoryTest extends RepositoryTest {
 
 	@Test
 	@DisplayName("댓글 번호로 조회 시에 회원을 조인해서 가져온다.")
 	void joinUserByCommentIdTest() {
-		// given
-		User user = userRepository.save(USER);
-		Post post = getPost();
-		post.setUser(user);
-		Post savedPost = postRepository.save(post);
-		Comment comment = Comment.builder()
-			.user(user)
-			.post(savedPost)
-			.content("댓글 내용")
-			.build();
-		Comment savedComment = commentRepository.save(comment);
-		// when
+		// given & when
 		Comment findComment = commentRepository.joinUserByCommentId(savedComment.getId());
 		// then
 		assertThat(findComment).isNotNull();

--- a/src/test/java/com/prgrms/prolog/domain/comment/service/CommentServiceImplTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/comment/service/CommentServiceImplTest.java
@@ -7,18 +7,16 @@ import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class CommentServiceImplTest {
+import com.prgrms.prolog.base.ServiceTest;
 
-	@Mock
-	CommentServiceImpl commentService;
+class CommentServiceImplTest extends ServiceTest {
 
 	final CreateCommentRequest CREATE_COMMENT_REQUEST = new CreateCommentRequest(COMMENT.getContent());
 	final UpdateCommentRequest UPDATE_COMMENT_REQUEST = new UpdateCommentRequest(COMMENT.getContent() + "updated");
+	@Mock
+	CommentServiceImpl commentService;
 
 	@Test
 	@DisplayName("댓글 저장에 성공한다.")

--- a/src/test/java/com/prgrms/prolog/domain/like/repository/LikeRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/like/repository/LikeRepositoryTest.java
@@ -1,63 +1,28 @@
 package com.prgrms.prolog.domain.like.repository;
 
-import static com.prgrms.prolog.utils.TestUtils.*;
+
 import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.*;
 
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
+import com.prgrms.prolog.base.RepositoryTest;
 import com.prgrms.prolog.domain.like.model.Like;
-import com.prgrms.prolog.domain.post.model.Post;
-import com.prgrms.prolog.domain.post.repository.PostRepository;
-import com.prgrms.prolog.domain.user.model.User;
-import com.prgrms.prolog.domain.user.repository.UserRepository;
-import com.prgrms.prolog.global.config.JpaConfig;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = NONE)
-@Import({JpaConfig.class})
-class LikeRepositoryTest {
 
-	@Autowired
-	LikeRepository likeRepository;
+class LikeRepositoryTest extends RepositoryTest {
 
-	@Autowired
-	PostRepository postRepository;
-
-	@Autowired
-	UserRepository userRepository;
 
 	@Test
 	@DisplayName("존재하는 사용자가 존재하는 게시물을 좋아요를 할 때 좋아요가 생긴다.")
 	void findByUserAndPostTest() {
-		// given
-		User savedUser = userRepository.save(USER);
-		Post post = Post.builder()
-			.title(TITLE)
-			.content(CONTENT)
-			.openStatus(true)
-			.user(savedUser)
-			.build();
-		Post savedPost = postRepository.save(post);
-
-		Like like = Like.builder()
-			.user(savedUser)
-			.post(savedPost)
-			.build();
-		Like savedLike = likeRepository.save(like);
-
 		// when
 		Optional<Like> actual = likeRepository.findByUserAndPost(savedUser, savedPost);
 
 		// then
 		assertThat(actual)
-			.hasValueSatisfying(l -> assertThat(l.getId()).isEqualTo(savedLike.getId()));
+			.hasValueSatisfying(like -> assertThat(like.getId()).isEqualTo(savedLike.getId()));
 	}
 }

--- a/src/test/java/com/prgrms/prolog/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/like/service/LikeServiceTest.java
@@ -10,36 +10,17 @@ import javax.persistence.EntityNotFoundException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.prgrms.prolog.base.ServiceTest;
 import com.prgrms.prolog.domain.like.dto.LikeDto.likeRequest;
 import com.prgrms.prolog.domain.like.model.Like;
-import com.prgrms.prolog.domain.like.repository.LikeRepository;
-import com.prgrms.prolog.domain.post.repository.PostRepository;
-import com.prgrms.prolog.domain.user.repository.UserRepository;
 
-@ExtendWith(MockitoExtension.class)
-class LikeServiceTest {
+class LikeServiceTest extends ServiceTest {
 
+	private static final likeRequest likeRequest = new likeRequest(USER_ID, POST_ID);
 	@InjectMocks
 	private LikeServiceImpl likeService;
-
-	@Mock
-	private LikeRepository likeRepository;
-
-	@Mock
-	private PostRepository postRepository;
-
-	@Mock
-	private UserRepository userRepository;
-
-	@Mock
-	private Like like;
-
-	likeRequest likeRequest = new likeRequest(USER_ID, POST_ID);
 
 	@Test
 	@DisplayName("게시물에 좋아요를 누를 수 있다.")
@@ -77,20 +58,24 @@ class LikeServiceTest {
 	@Test
 	@DisplayName("좋아요한 게시물에 또 좋아요를 할 수 없다.")
 	void insertDuplicateLikeTest() {
+		// given
 		given(userRepository.findById(USER_ID)).willReturn(Optional.of(USER));
 		given(postRepository.findById(POST_ID)).willReturn(Optional.of(POST));
 		given(likeRepository.findByUserAndPost(USER, POST)).willReturn(Optional.of(LIKE));
 
+		// when & then
 		assertThatThrownBy(() -> likeService.save(likeRequest)).isInstanceOf(EntityNotFoundException.class);
 	}
 
 	@Test
 	@DisplayName("좋아요를 하지 않은 게시물에는 좋아요를 취소할 수 없다.")
 	void cancelDuplicateLikeTest() {
+		// given
 		given(userRepository.findById(USER_ID)).willReturn(Optional.of(USER));
 		given(postRepository.findById(POST_ID)).willReturn(Optional.of(POST));
 		given(likeRepository.findByUserAndPost(USER, POST)).willThrow(EntityNotFoundException.class);
 
+		// when & then
 		assertThatThrownBy(() -> likeService.save(likeRequest)).isInstanceOf(EntityNotFoundException.class);
 	}
 
@@ -109,7 +94,7 @@ class LikeServiceTest {
 		likeService.save(likeRequest);
 
 		// then
-		then(postRepository).should().addLikeCount(any());    // 행위 검증
+		then(postRepository).should().addLikeCount(any());
 		assertThat(postRepository.addLikeCount(POST_ID)).isEqualTo(1);
 	}
 
@@ -120,7 +105,6 @@ class LikeServiceTest {
 		given(userRepository.findById(USER_ID)).willReturn(Optional.of(USER));
 		given(postRepository.findById(POST_ID)).willReturn(Optional.of(POST));
 		given(likeRepository.findByUserAndPost(USER, POST)).willReturn(Optional.of(LIKE));
-		willDoNothing().given(likeRepository).delete(any(Like.class));
 		given(postRepository.subLikeCount(any())).willReturn(1);
 
 		// when

--- a/src/test/java/com/prgrms/prolog/domain/post/model/PostTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/post/model/PostTest.java
@@ -11,24 +11,22 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class PostTest {
 
-	private static final String title = "제목";
-	private static final String content = "내용";
 
 	@Test
 	@DisplayName("게시글 생성")
 	void createPostTest() {
 		//given
 		Post post = Post.builder()
-			.title(title)
-			.content(content)
+			.title(POST_TITLE)
+			.content(POST_CONTENT)
 			.openStatus(true)
 			.user(USER)
 			.build();
 		// when & then
 		assertAll(
 			() -> assertThat(post)
-				.hasFieldOrPropertyWithValue("title", title)
-				.hasFieldOrPropertyWithValue("content", content)
+				.hasFieldOrPropertyWithValue("title", POST_TITLE)
+				.hasFieldOrPropertyWithValue("content", POST_CONTENT)
 				.hasFieldOrPropertyWithValue("openStatus", true),
 			() -> assertThat(post.getUser()).isEqualTo(USER)
 		);
@@ -54,7 +52,7 @@ class PostTest {
 	@DisplayName("게시글을 생성하기 위해서는 사용자가 필요하다.")
 	void createFailByUserNullTest() {
 		//given & when & then
-		assertThatThrownBy(() -> new Post(title, content, true, null,null))
+		assertThatThrownBy(() -> new Post(POST_TITLE, POST_CONTENT, true, null,null))
 			.isInstanceOf(NullPointerException.class);
 	}
 
@@ -62,7 +60,7 @@ class PostTest {
 	@DisplayName("게시글 제목은 50자를 넘을 수 없다.")
 	void validateTitleTest() {
 		//given & when & then
-		assertThatThrownBy(() -> new Post(OVER_SIZE_50, content, true, USER, null))
+		assertThatThrownBy(() -> new Post(OVER_SIZE_50, POST_CONTENT, true, USER, null))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 
@@ -71,7 +69,7 @@ class PostTest {
 	@DisplayName("게시글 제목은 빈 값,null일 수 없다.")
 	void validateTitleTest2(String inputTitle) {
 		//given & when & then
-		assertThatThrownBy(() -> new Post(inputTitle, content, true, USER, null))
+		assertThatThrownBy(() -> new Post(inputTitle, POST_CONTENT, true, USER, null))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 
@@ -79,7 +77,7 @@ class PostTest {
 	@DisplayName("게시글 내용은 65535자를 넘을 수 없다.")
 	void validateContentTest() {
 		//given & when & then
-		assertThatThrownBy(() -> new Post(title, OVER_SIZE_65535, true, USER, null))
+		assertThatThrownBy(() -> new Post(POST_TITLE, OVER_SIZE_65535, true, USER, null))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 
@@ -88,7 +86,7 @@ class PostTest {
 	@DisplayName("게시글 내용은 빈 값,null일 수 없다.")
 	void validateContentTest2(String inputContent) {
 		//given & when & then
-		assertThatThrownBy(() -> new Post(title, inputContent, true, USER, null))
+		assertThatThrownBy(() -> new Post(POST_TITLE, inputContent, true, USER, null))
 			.isInstanceOf(IllegalArgumentException.class);
 	}
 

--- a/src/test/java/com/prgrms/prolog/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/post/repository/PostRepositoryTest.java
@@ -1,51 +1,19 @@
 package com.prgrms.prolog.domain.post.repository;
 
-import static com.prgrms.prolog.utils.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
+import com.prgrms.prolog.base.RepositoryTest;
 import com.prgrms.prolog.domain.post.model.Post;
-import com.prgrms.prolog.domain.user.model.User;
-import com.prgrms.prolog.domain.user.repository.UserRepository;
-import com.prgrms.prolog.global.config.JpaConfig;
 
-@DataJpaTest
-@Import({JpaConfig.class})
-@AutoConfigureTestDatabase(replace = Replace.NONE)
-class PostRepositoryTest {
+class PostRepositoryTest extends RepositoryTest {
 
 	private static final String NOT_EXIST_POST = "해당 게시물은 존재하지 않는 게시물입니다.";
-	@Autowired
-	UserRepository userRepository;
-
-	@Autowired
-	PostRepository postRepository;
-
-	User user;
-	Post post;
-
-	@BeforeEach
-	void setUp() {
-		user = userRepository.save(USER);
-		Post p = Post.builder()
-			.title(TITLE)
-			.content(CONTENT)
-			.openStatus(true)
-			.user(user)
-			.build();
-		post = postRepository.save(p);
-	}
 
 	@Test
 	@DisplayName("게시물을 등록할 수 있다.")
@@ -54,7 +22,7 @@ class PostRepositoryTest {
 			.title("새로 저장한 제목")
 			.content("새로 저장한 내용")
 			.openStatus(false)
-			.user(user)
+			.user(savedUser)
 			.build();
 
 		Post savePost = postRepository.save(newPost);
@@ -66,10 +34,10 @@ class PostRepositoryTest {
 	@DisplayName("아이디로 게시물을 단건 조회할 수 있다.")
 	void findById() {
 
-		Post findPost = postRepository.findById(post.getId())
+		Post findPost = postRepository.findById(savedPost.getId())
 			.orElseThrow(() -> new IllegalArgumentException(NOT_EXIST_POST));
 
-		assertThat(findPost.getId()).isEqualTo(post.getId());
+		assertThat(findPost.getId()).isEqualTo(savedPost.getId());
 	}
 
 	@Test
@@ -87,11 +55,11 @@ class PostRepositoryTest {
 		String changeContent = "변경된 게시물 내용";
 		boolean changeOpenStatus = true;
 
-		post.changeTitle(changeTitle);
-		post.changeContent(changeContent);
-		post.changeOpenStatus(changeOpenStatus);
+		savedPost.changeTitle(changeTitle);
+		savedPost.changeContent(changeContent);
+		savedPost.changeOpenStatus(changeOpenStatus);
 
-		Post findPost = postRepository.findById(post.getId())
+		Post findPost = postRepository.findById(savedPost.getId())
 			.orElseThrow(() -> new IllegalArgumentException(NOT_EXIST_POST));
 
 		assertThat(findPost.getTitle()).isEqualTo(changeTitle);
@@ -102,9 +70,9 @@ class PostRepositoryTest {
 	@Test
 	@DisplayName("아이디로 게시물을 삭제할 수 있다.")
 	void delete() {
-		postRepository.delete(post);
+		postRepository.delete(savedPost);
 
-		Optional<Post> findPost = postRepository.findById(post.getId());
+		Optional<Post> findPost = postRepository.findById(savedPost.getId());
 
 		assertThat(findPost).isEmpty();
 	}

--- a/src/test/java/com/prgrms/prolog/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/post/service/PostServiceTest.java
@@ -1,6 +1,5 @@
 package com.prgrms.prolog.domain.post.service;
 
-import static com.prgrms.prolog.domain.series.dto.SeriesResponse.*;
 import static com.prgrms.prolog.utils.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -134,8 +133,7 @@ class PostServiceTest {
 			.hasFieldOrPropertyWithValue("title", request.title())
 			.hasFieldOrPropertyWithValue("content", request.content())
 			.hasFieldOrPropertyWithValue("openStatus", request.openStatus())
-			.hasFieldOrPropertyWithValue("tags", Set.of("테스트"))
-			.hasFieldOrPropertyWithValue("seriesResponse", toSeriesResponse(savedSeries));
+			.hasFieldOrPropertyWithValue("tags", Set.of("테스트"));
 	}
 
 	@Test
@@ -168,7 +166,8 @@ class PostServiceTest {
 	@Test
 	@DisplayName("존재하는 게시물의 아이디로 게시물의 제목, 내용, 태그, 공개범위를 수정할 수 있다.")
 	void update_success() {
-		final CreateRequest createRequest = new CreateRequest("테스트 제목", "테스트 내용", "#테스트#test#test1#테 스트", true,SERIES_TITLE);
+		final CreateRequest createRequest = new CreateRequest("테스트 제목", "테스트 내용", "#테스트#test#test1#테 스트", true,
+			SERIES_TITLE);
 		Long savedPost = postService.save(createRequest, user.getId());
 
 		final UpdateRequest updateRequest = new UpdateRequest("수정된 테스트", "수정된 테스트 내용", "#테스트#수정된 태그", true);

--- a/src/test/java/com/prgrms/prolog/domain/roottag/repository/RootTagRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/roottag/repository/RootTagRepositoryTest.java
@@ -7,18 +7,15 @@ import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import com.prgrms.prolog.base.RepositoryTest;
 import com.prgrms.prolog.domain.roottag.model.RootTag;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = NONE)
-class RootTagRepositoryTest {
-
-	@Autowired
-	RootTagRepository rootTagRepository;
+class RootTagRepositoryTest extends RepositoryTest {
 
 	@Test
 	@DisplayName("태그 이름들로 루트 태그들을 검색한다.")

--- a/src/test/java/com/prgrms/prolog/domain/series/api/SeriesControllerTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/series/api/SeriesControllerTest.java
@@ -1,71 +1,35 @@
 package com.prgrms.prolog.domain.series.api;
 
-import static com.prgrms.prolog.global.jwt.JwtTokenProvider.*;
 import static com.prgrms.prolog.utils.TestUtils.*;
 import static org.springframework.http.HttpHeaders.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
-import com.prgrms.prolog.config.RestDocsConfig;
+import com.prgrms.prolog.base.ControllerTest;
 import com.prgrms.prolog.domain.post.model.Post;
 import com.prgrms.prolog.domain.post.repository.PostRepository;
 import com.prgrms.prolog.domain.series.model.Series;
 import com.prgrms.prolog.domain.series.repository.SeriesRepository;
-import com.prgrms.prolog.domain.user.model.User;
-import com.prgrms.prolog.domain.user.repository.UserRepository;
-import com.prgrms.prolog.global.jwt.JwtTokenProvider;
 
-@SpringBootTest
-@ExtendWith(RestDocumentationExtension.class)
-@Import(RestDocsConfig.class)
-@Transactional
-class SeriesControllerTest {
+class SeriesControllerTest extends ControllerTest {
 
-	@Autowired
-	private JwtTokenProvider jwtTokenProvider;
-	@Autowired
-	private RestDocumentationResultHandler restDocs;
-	@Autowired
-	private UserRepository userRepository;
 	@Autowired
 	private PostRepository postRepository;
 	@Autowired
 	private SeriesRepository seriesRepository;
 
-	private MockMvc mockMvc;
-	private User savedUser;
 	private Post savedPost;
 	private Series savedSeries;
 
 	@BeforeEach
-	void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
-		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-			.addFilter(new CharacterEncodingFilter("UTF-8", true))
-			.apply(documentationConfiguration(provider))
-			.apply(springSecurity())
-			.alwaysDo(restDocs)
-			.build();
-		savedUser = userRepository.save(USER);
+	void setUpSeries() {
 		Post post = Post.builder()
 			.title(POST_TITLE)
 			.content(POST_CONTENT)
@@ -84,11 +48,9 @@ class SeriesControllerTest {
 	@Test
 	@DisplayName("자신이 가진 시리즈 중에서 제목으로 게시글 정보를 조회할 수 있다.")
 	void findSeriesByTitleTest() throws Exception {
-		// given
-		Claims claims = Claims.from(savedUser.getId(), USER_ROLE);
 		// when
 		mockMvc.perform(get("/api/v1/series")
-				.header(AUTHORIZATION, BEARER_TYPE + jwtTokenProvider.createAccessToken(claims))
+				.header(AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
 				.param("title", SERIES_TITLE)
 			)
 			// then

--- a/src/test/java/com/prgrms/prolog/domain/series/repository/SeriesRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/series/repository/SeriesRepositoryTest.java
@@ -5,44 +5,13 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
+import com.prgrms.prolog.base.RepositoryTest;
 import com.prgrms.prolog.domain.series.model.Series;
-import com.prgrms.prolog.domain.user.model.User;
-import com.prgrms.prolog.domain.user.repository.UserRepository;
-import com.prgrms.prolog.global.config.JpaConfig;
 
-
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import({JpaConfig.class})
-public class SeriesRepositoryTest {
-
-	@Autowired
-	private SeriesRepository seriesRepository;
-
-	@Autowired
-	private UserRepository userRepository;
-
-	private Series savedSeries;
-	private User savedUser;
-
-	@BeforeEach
-	void setUp() {
-		savedUser = userRepository.save(USER);
-		Series series = Series.builder()
-			.title(SERIES_TITLE)
-			.user(savedUser)
-			.build();
-		savedSeries = seriesRepository.save(series);
-	}
+public class SeriesRepositoryTest extends RepositoryTest {
 
 	@Test
 	@DisplayName("해당 유저가 가진 시리즈 중에서 찾는 제목의 시리즈를 조회한다.")
@@ -53,13 +22,4 @@ public class SeriesRepositoryTest {
 		assertThat(series).isPresent();
 	}
 
-	@Disabled
-	@Test
-	@DisplayName("포스트 조회시 N+1 테스트")
-	void nPlus1Test() {
-		// given & when
-		Optional<Series> series = seriesRepository.findByIdAndTitle(savedUser.getId(), SERIES_TITLE);
-		// then
-		assertThat(series).isPresent();
-	}
 }

--- a/src/test/java/com/prgrms/prolog/domain/user/Repository/UserRepositoryTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/user/Repository/UserRepositoryTest.java
@@ -2,38 +2,16 @@ package com.prgrms.prolog.domain.user.Repository;
 
 import static com.prgrms.prolog.utils.TestUtils.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.*;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.transaction.annotation.Transactional;
 
+import com.prgrms.prolog.base.RepositoryTest;
 import com.prgrms.prolog.domain.user.model.User;
-import com.prgrms.prolog.domain.user.repository.UserRepository;
-import com.prgrms.prolog.global.config.JpaConfig;
 
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({JpaConfig.class})
-@Transactional
-class UserRepositoryTest {
-
-	@Autowired
-	private UserRepository userRepository;
-
-	private User savedUser;
-
-	@BeforeEach
-	void setUp() {
-		savedUser = userRepository.save(getUser());
-	}
+class UserRepositoryTest extends RepositoryTest {
 
 	@Test
 	@DisplayName("저장된 유저 정보를 유저ID로 찾아 가져올 수 있다.")
@@ -50,10 +28,8 @@ class UserRepositoryTest {
 	@Test
 	@DisplayName("저장되지 않은 유저는 조회할 수 없다.")
 	void findFailTest() {
-		// given
-		Long unsavedUserId = 0L;
 		// when
-		Optional<User> foundUser = userRepository.findById(unsavedUserId);
+		Optional<User> foundUser = userRepository.findById(UNSAVED_USER_ID);
 		// then
 		assertThat(foundUser).isNotPresent();
 	}

--- a/src/test/java/com/prgrms/prolog/domain/user/api/UserControllerTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/user/api/UserControllerTest.java
@@ -1,72 +1,25 @@
 package com.prgrms.prolog.domain.user.api;
 
-import static com.prgrms.prolog.global.jwt.JwtTokenProvider.*;
 import static com.prgrms.prolog.utils.TestUtils.*;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.filter.CharacterEncodingFilter;
 
-import com.prgrms.prolog.config.RestDocsConfig;
-import com.prgrms.prolog.domain.user.model.User;
-import com.prgrms.prolog.domain.user.repository.UserRepository;
-import com.prgrms.prolog.domain.user.service.UserServiceImpl;
-import com.prgrms.prolog.global.jwt.JwtTokenProvider;
+import com.prgrms.prolog.base.ControllerTest;
 
-@SpringBootTest
-@ExtendWith(RestDocumentationExtension.class)
-@Import(RestDocsConfig.class)
-@Transactional
-class UserControllerTest {
-
-	protected MockMvc mockMvc;
-	@Autowired
-	private JwtTokenProvider jwtTokenProvider;
-	@Autowired
-	private RestDocumentationResultHandler restDocs;
-	@Autowired
-	private UserServiceImpl userService;
-	@Autowired
-	private UserRepository userRepository;
-
-	@BeforeEach
-	void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
-		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-			.addFilter(new CharacterEncodingFilter("UTF-8", true))
-			.apply(documentationConfiguration(provider))
-			.apply(springSecurity())
-			.alwaysDo(restDocs)
-			.build();
-	}
+class UserControllerTest extends ControllerTest {
 
 	@Test
 	@DisplayName("사용자는 자신의 프로필 정보를 확인할 수 있다")
 	void userPage() throws Exception {
-		// given
-		User savedUser = userRepository.save(USER);
-		Claims claims = Claims.from(savedUser.getId(), USER_ROLE);
 		// when
 		mockMvc.perform(RestDocumentationRequestBuilders.get("/api/v1/user/me")
-				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + jwtTokenProvider.createAccessToken(claims))
+				.header(HttpHeaders.AUTHORIZATION, BEARER_TYPE + ACCESS_TOKEN)
 			)
 			// then
 			.andExpectAll(

--- a/src/test/java/com/prgrms/prolog/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/prolog/domain/user/service/UserServiceTest.java
@@ -9,25 +9,15 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.prgrms.prolog.base.ServiceTest;
 import com.prgrms.prolog.domain.user.dto.UserDto.IdResponse;
 import com.prgrms.prolog.domain.user.dto.UserDto.UserProfile;
 import com.prgrms.prolog.domain.user.model.User;
-import com.prgrms.prolog.domain.user.repository.UserRepository;
 
-@ExtendWith(MockitoExtension.class)
-class UserServiceTest {
-
-	@Mock
-	private UserRepository userRepository;
-
-	@Mock
-	private User userMock;
+class UserServiceTest extends ServiceTest {
 
 	@InjectMocks
 	private UserServiceImpl userService;
@@ -46,11 +36,11 @@ class UserServiceTest {
 				given(UserProfile.toUserProfile(USER)).willReturn(USER_PROFILE);
 
 				// when
-				UserProfile foundUser = userService.findUserProfileByUserId(USER_ID);
+				UserProfile foundUserProfile = userService.findUserProfileByUserId(USER_ID);
 
 				// then
 				then(userRepository).should().findById(USER_ID);
-				assertThat(foundUser)
+				assertThat(foundUserProfile)
 					.hasFieldOrPropertyWithValue("email", USER_EMAIL)
 					.hasFieldOrPropertyWithValue("nickName", USER_NICK_NAME)
 					.hasFieldOrPropertyWithValue("introduce", USER_INTRODUCE)
@@ -63,10 +53,9 @@ class UserServiceTest {
 		@Test
 		void notFoundMatchUser() {
 			//given
-			Long unsavedUserId = 100L;
 			given(userRepository.findById(any(Long.class))).willReturn(Optional.empty());
 			//when & then
-			assertThatThrownBy(() -> userService.findUserProfileByUserId(unsavedUserId))
+			assertThatThrownBy(() -> userService.findUserProfileByUserId(UNSAVED_USER_ID))
 				.isInstanceOf(IllegalArgumentException.class);
 		}
 	}
@@ -79,8 +68,8 @@ class UserServiceTest {
 		void signUpTest() {
 			// given
 			given(userRepository.findByProviderAndOauthId(PROVIDER,OAUTH_ID))
-				.willReturn(Optional.of(userMock));
-			given(userMock.getId()).willReturn(USER_ID);
+				.willReturn(Optional.of(user));
+			given(user.getId()).willReturn(USER_ID);
 			// when
 			IdResponse userId = userService.signUp(USER_INFO);
 			// then
@@ -93,8 +82,8 @@ class UserServiceTest {
 			// given
 			given(userRepository.findByProviderAndOauthId(PROVIDER, OAUTH_ID))
 				.willReturn(Optional.empty());
-			given(userRepository.save(any(User.class))).willReturn(userMock);
-			given(userMock.getId()).willReturn(USER_ID);
+			given(userRepository.save(any(User.class))).willReturn(user);
+			given(user.getId()).willReturn(USER_ID);
 			// when
 			IdResponse userId = userService.signUp(USER_INFO);
 			// then

--- a/src/test/java/com/prgrms/prolog/utils/TestUtils.java
+++ b/src/test/java/com/prgrms/prolog/utils/TestUtils.java
@@ -12,7 +12,7 @@ import com.prgrms.prolog.domain.user.model.User;
 
 public class TestUtils {
 
-	// User Data
+	// User
 	public static final Long USER_ID = 1L;
 	public static final User USER = getUser();
 	public static final Long UNSAVED_USER_ID = 0L;


### PR DESCRIPTION
## 🌱 작업 사항
 ### 테스트 코드에서 중복되는 부분이 많은 것 같아서 중복이 되는 영역을 추상클래스로 만들었습니다. 
- 각 Controller, Service, Repository Test라는 이름의 Base Class 를 상속 받아 사용하도록 하였습니다.
- 추후에는 TestUtil에는 상수만 남겨 두고 나머지생성 메서드는 삭제할 생각입니다. 코드 보시고 잘 모르겠으면 댓글로 남겨주시고, 코드를 리팩터링 해주시면 감사하겠습니다. 
## 🦄 관련 이슈
