### PR TITLE
AWS 지원 종료 이후 github action workflow 업데이트

### DIFF
--- a/.github/workflows/docker-push-and-aws-run.yml
+++ b/.github/workflows/docker-push-and-aws-run.yml
@@ -33,11 +33,11 @@ jobs:
           docker build -t fortune00/prolog .
           docker push fortune00/prolog:latest
 
-      - name: Access aws server and run the app
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.AWS_HOST }}
-          username: ${{ secrets.AWS_USERNAME }}
-          key: ${{ secrets.AWS_KEY }}
-          script: #docker-compose.yml ./.env ./nginx/default.conf ./deploy.sh 서버에 초기화
-            bash deploy.sh
+#      - name: Access aws server and run the app
+#        uses: appleboy/ssh-action@master
+#        with:
+#          host: ${{ secrets.AWS_HOST }}
+#          username: ${{ secrets.AWS_USERNAME }}
+#          key: ${{ secrets.AWS_KEY }}
+#          script: #docker-compose.yml ./.env ./nginx/default.conf ./deploy.sh 서버에 초기화
+#            bash deploy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 .vscode/
 /src/main/resources/properties/db.properties
 /.env
+logs

--- a/src/main/java/com/prgrms/prolog/global/file/api/FileController.java
+++ b/src/main/java/com/prgrms/prolog/global/file/api/FileController.java
@@ -1,4 +1,4 @@
-package com.prgrms.prolog.global.image.api;
+package com.prgrms.prolog.global.file.api;
 
 import static com.prgrms.prolog.global.config.MessageKeyConfig.*;
 
@@ -11,16 +11,16 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.prgrms.prolog.global.image.dto.UploadFileResponse;
-import com.prgrms.prolog.global.image.util.FileManager;
-import com.prgrms.prolog.global.image.util.UploadFileToS3;
+import com.prgrms.prolog.global.file.dto.UploadFileResponse;
+import com.prgrms.prolog.global.file.util.FileManager;
+import com.prgrms.prolog.global.file.util.UploadFileToS3;
 
 import lombok.RequiredArgsConstructor;
 
 @Profile("!test")
 @RestController
 @RequiredArgsConstructor
-public class ImageController {
+public class FileController {
 
 	private static final String FILE_PATH = "posts";
 	private final FileManager fileManager;

--- a/src/main/java/com/prgrms/prolog/global/file/dto/UploadFileResponse.java
+++ b/src/main/java/com/prgrms/prolog/global/file/dto/UploadFileResponse.java
@@ -1,4 +1,4 @@
-package com.prgrms.prolog.global.image.dto;
+package com.prgrms.prolog.global.file.dto;
 
 public record UploadFileResponse(
         String originalFileName,

--- a/src/main/java/com/prgrms/prolog/global/file/util/FileManager.java
+++ b/src/main/java/com/prgrms/prolog/global/file/util/FileManager.java
@@ -1,4 +1,4 @@
-package com.prgrms.prolog.global.image.util;
+package com.prgrms.prolog.global.file.util;
 
 import static com.prgrms.prolog.global.config.MessageKeyConfig.*;
 

--- a/src/main/java/com/prgrms/prolog/global/file/util/UploadFileToS3.java
+++ b/src/main/java/com/prgrms/prolog/global/file/util/UploadFileToS3.java
@@ -1,4 +1,4 @@
-package com.prgrms.prolog.global.image.util;
+package com.prgrms.prolog.global.file.util;
 
 import java.io.File;
 


### PR DESCRIPTION
## 🌱 작업 사항
- CICD의 워크플로우에 aws로의 배포를 중단
- 파일을 전송하는 api는 막지 않았으나, 사용할 수 없음
- 파일 전송 관련 패키지와 클래스의 이름을 변경하는 리펙토링

## 🦄 관련 이슈
